### PR TITLE
Specify codeowners by name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,4 @@
 ######################################################################
 # These owners will be the default owners for everything in the repo #
 ######################################################################
-*       @github/services-devops-engineers
-*       @github/services-implementation-engineers
-*       @github/services-solution-architects
-*       @github/data-portability
+*       @admiralawkbar, @jwiebalk, @zkoppert


### PR DESCRIPTION
Made this change with code spaces from my iPad which is awesome! Digital signature even worked somehow! Wow.

`CODEOWNERS` isn’t working in terms of automatically being applied to new pull requests. I think that it was because those groups that it specified are not public groups so I switched it to specify our names instead.


Signed-off-by: Zack Koppert <zkoppert@github.com>