### PR TITLE
Fix capitalization [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Developers on **GitHub** can call the **GitHub Action** to lint their code base 
 | **YAML** | Yamllint |
 | **Python3** | Pylint |
 | **JSON** | JsonLint |
-| **MarkDown** | Markdownlint |
+| **Markdown** | Markdownlint |
 | **Perl** | Perl |
 | **XML** | LibXML |
-| **Coffeescript** | coffeelint |
-| **Javascript** | eslint standard |
-| **Typescript** | eslint standard |
+| **CoffeeScript** | coffeelint |
+| **JavaScript** | eslint standard |
+| **TypeScript** | eslint standard |
 | **Golang** | golangci-lint |
 | **Dockerfile** | dockerfilelint |
 | **Terraform** | tflint |
@@ -157,9 +157,9 @@ The **Super-Linter** has *CI/CT/CD* configured utilizing **GitHub** Actions.
   - **Note:** The branches **Docker** container is also removed from **DockerHub** to cleanup after itself
 
 ## Limitations
-Below are a list of the known limitations for the **Github Super-Linter**:
+Below are a list of the known limitations for the **GitHub Super-Linter**:
 - Due to being completely packaged at run time, you will not be able to update dependencies or change versions of the enclosed linters and binaries
-- Reading additional details from `package.json` are not read by the **Github Super-Linter**
+- Reading additional details from `package.json` are not read by the **GitHub Super-Linter**
 - Downloading additional codebases as dependencies from private repositories will fail due to lack of permissions
 
 ## How to contribute


### PR DESCRIPTION
* Markdown [1,2] has no capital 'd'
* CoffeeScript [3,4], JavaScript [5,6], TypeScript [7,8,9] all capitalize 'S'
* GitHub [10,11] capitalizes the 'H'

References:

[1] https://en.wikipedia.org/wiki/Markdown
[2] https://daringfireball.net/projects/markdown/syntax
[3] https://en.wikipedia.org/wiki/CoffeeScript
[4] https://coffeescript.org/
[5] https://en.wikipedia.org/wiki/JavaScript
[6] https://developer.mozilla.org/en-US/docs/Web/JavaScript
[7] https://en.wikipedia.org/wiki/TypeScript
[8] https://www.typescriptlang.org/
[9] https://github.com/Microsoft/TypeScript
[10] https://en.wikipedia.org/wiki/GitHub
[11] https://github.com/about