### PR TITLE
Tweak readme linter list

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,21 @@ Developers on **GitHub** can call the **GitHub Action** to lint their code base 
 
 | *Language* | *Linter* |
 |---|---|
-| **Ruby** | RuboCop |
-| **Shell** | Shellcheck |
-| **Ansible** | Ansible-lint |
-| **YAML** | Yamllint |
-| **Python3** | Pylint |
-| **JSON** | JsonLint |
-| **Markdown** | markdownlint |
-| **Perl** | Perl |
-| **XML** | LibXML |
-| **CoffeeScript** | coffeelint |
-| **JavaScript** | eslint standard |
-| **TypeScript** | eslint standard |
-| **Golang** | golangci-lint |
-| **Dockerfile** | dockerfilelint |
-| **Terraform** | tflint |
+| **Ruby** | [Rubocop](https://github.com/rubocop-hq/rubocop) |
+| **Shell** | [Shellcheck](https://github.com/koalaman/shellcheck) |
+| **Ansible** | [ansible-lint](https://github.com/ansible/ansible-lint) |
+| **YAML** | [YamlLint](https://github.com/adrienverge/yamllint) |
+| **Python3** | [pylint](https://www.pylint.org/) |
+| **JSON** | [jsonlint](https://github.com/zaach/jsonlint) |
+| **Markdown** | [markdownlint](https://github.com/igorshubovych/markdownlint-cli#readme) |
+| **Perl** | [perl](https://pkgs.alpinelinux.org/package/edge/main/x86/perl) |
+| **XML** | [LibXML](http://xmlsoft.org/) |
+| **CoffeeScript** | [coffeelint](http://www.coffeelint.org/) |
+| **JavaScript** | [eslint](https://eslint.org/) [standard js](https://standardjs.com/) |
+| **TypeScript** | [eslint](https://eslint.org/) [standard js](https://standardjs.com/) |
+| **Golang** | [golangci-lint](https://github.com/golangci/golangci-lint) |
+| **Dockerfile** | [dockerfilelint](https://github.com/replicatedhq/dockerfilelint.git) |
+| **Terraform** | [tflint](https://github.com/terraform-linters/tflint) |
 
 ## How to use
 To use this **GitHub** Action you will need to complete the following:

--- a/README.md
+++ b/README.md
@@ -16,23 +16,23 @@ The super-linter finds issues and reports them to the console output. Fixes are 
 
 Developers on **GitHub** can call the **GitHub Action** to lint their code base with the following list of linters:
 
-| *Language* | *Linter* |
-|---|---|
-| **Ansible** | [ansible-lint](https://github.com/ansible/ansible-lint) |
-| **CoffeeScript** | [coffeelint](http://www.coffeelint.org/) |
-| **Dockerfile** | [dockerfilelint](https://github.com/replicatedhq/dockerfilelint.git) |
-| **Golang** | [golangci-lint](https://github.com/golangci/golangci-lint) |
-| **JavaScript** | [eslint](https://eslint.org/) [standard js](https://standardjs.com/) |
-| **JSON** | [jsonlint](https://github.com/zaach/jsonlint) |
-| **Markdown** | [markdownlint](https://github.com/igorshubovych/markdownlint-cli#readme) |
-| **Perl** | [perl](https://pkgs.alpinelinux.org/package/edge/main/x86/perl) |
-| **Python3** | [pylint](https://www.pylint.org/) |
-| **Ruby** | [Rubocop](https://github.com/rubocop-hq/rubocop) |
-| **Shell** | [Shellcheck](https://github.com/koalaman/shellcheck) |
-| **Terraform** | [tflint](https://github.com/terraform-linters/tflint) |
-| **TypeScript** | [eslint](https://eslint.org/) [standard js](https://standardjs.com/) |
-| **XML** | [LibXML](http://xmlsoft.org/) |
-| **YAML** | [YamlLint](https://github.com/adrienverge/yamllint) |
+| *Language*       | *Linter*                                                                 |
+| ---              | ---                                                                      |
+| **Ansible**      | [ansible-lint](https://github.com/ansible/ansible-lint)                  |
+| **CoffeeScript** | [coffeelint](http://www.coffeelint.org/)                                 |
+| **Dockerfile**   | [dockerfilelint](https://github.com/replicatedhq/dockerfilelint.git)     |
+| **Golang**       | [golangci-lint](https://github.com/golangci/golangci-lint)               |
+| **JavaScript**   | [eslint](https://eslint.org/) [standard js](https://standardjs.com/)     |
+| **JSON**         | [jsonlint](https://github.com/zaach/jsonlint)                            |
+| **Markdown**     | [markdownlint](https://github.com/igorshubovych/markdownlint-cli#readme) |
+| **Perl**         | [perl](https://pkgs.alpinelinux.org/package/edge/main/x86/perl)          |
+| **Python3**      | [pylint](https://www.pylint.org/)                                        |
+| **Ruby**         | [Rubocop](https://github.com/rubocop-hq/rubocop)                         |
+| **Shell**        | [Shellcheck](https://github.com/koalaman/shellcheck)                     |
+| **Terraform**    | [tflint](https://github.com/terraform-linters/tflint)                    |
+| **TypeScript**   | [eslint](https://eslint.org/) [standard js](https://standardjs.com/)     |
+| **XML**          | [LibXML](http://xmlsoft.org/)                                            |
+| **YAML**         | [YamlLint](https://github.com/adrienverge/yamllint)                      |
 
 ## How to use
 To use this **GitHub** Action you will need to complete the following:

--- a/README.md
+++ b/README.md
@@ -18,21 +18,21 @@ Developers on **GitHub** can call the **GitHub Action** to lint their code base 
 
 | *Language* | *Linter* |
 |---|---|
-| **Ruby** | [Rubocop](https://github.com/rubocop-hq/rubocop) |
-| **Shell** | [Shellcheck](https://github.com/koalaman/shellcheck) |
 | **Ansible** | [ansible-lint](https://github.com/ansible/ansible-lint) |
-| **YAML** | [YamlLint](https://github.com/adrienverge/yamllint) |
-| **Python3** | [pylint](https://www.pylint.org/) |
+| **CoffeeScript** | [coffeelint](http://www.coffeelint.org/) |
+| **Dockerfile** | [dockerfilelint](https://github.com/replicatedhq/dockerfilelint.git) |
+| **Golang** | [golangci-lint](https://github.com/golangci/golangci-lint) |
+| **JavaScript** | [eslint](https://eslint.org/) [standard js](https://standardjs.com/) |
 | **JSON** | [jsonlint](https://github.com/zaach/jsonlint) |
 | **Markdown** | [markdownlint](https://github.com/igorshubovych/markdownlint-cli#readme) |
 | **Perl** | [perl](https://pkgs.alpinelinux.org/package/edge/main/x86/perl) |
-| **XML** | [LibXML](http://xmlsoft.org/) |
-| **CoffeeScript** | [coffeelint](http://www.coffeelint.org/) |
-| **JavaScript** | [eslint](https://eslint.org/) [standard js](https://standardjs.com/) |
-| **TypeScript** | [eslint](https://eslint.org/) [standard js](https://standardjs.com/) |
-| **Golang** | [golangci-lint](https://github.com/golangci/golangci-lint) |
-| **Dockerfile** | [dockerfilelint](https://github.com/replicatedhq/dockerfilelint.git) |
+| **Python3** | [pylint](https://www.pylint.org/) |
+| **Ruby** | [Rubocop](https://github.com/rubocop-hq/rubocop) |
+| **Shell** | [Shellcheck](https://github.com/koalaman/shellcheck) |
 | **Terraform** | [tflint](https://github.com/terraform-linters/tflint) |
+| **TypeScript** | [eslint](https://eslint.org/) [standard js](https://standardjs.com/) |
+| **XML** | [LibXML](http://xmlsoft.org/) |
+| **YAML** | [YamlLint](https://github.com/adrienverge/yamllint) |
 
 ## How to use
 To use this **GitHub** Action you will need to complete the following:


### PR DESCRIPTION
I used small commits for easier verification and for piecemeal use, if, say, aligning the columns was too much. Feel free to squash when merging. 

Fixes #132.