### PR TITLE
Apply valid syntax to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 ######################################################################
 # These owners will be the default owners for everything in the repo #
 ######################################################################
-*       @admiralawkbar, @jwiebalk, @zkoppert
+*       @admiralawkbar @jwiebalk @zkoppert


### PR DESCRIPTION
According to the following resource there's no comma separator in the CODEOWNERS file.

See: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
