### PR TITLE
docs(readme): fix typo languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The super-linter allows you to pass the following `ENV` variables to be able to 
 *Note:* All the `VALIDATE_[LANGUAGE]` variables behave in a specific way.  
 If none of them are passed, then they all default to true.  
 However if any one of the variables are set, we default to leaving any unset variable to false.  
-This means that if you run the linter "out of the box", all langauges will be checked.
+This means that if you run the linter "out of the box", all languages will be checked.
 But if you wish to select specific linters, we give you full control to choose which linters are run,
 and won't run anything unexpected.
 


### PR DESCRIPTION
Just a small typo fix.