### PR TITLE
Update docs to point to github docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ You can use the **GitHub** **Super-Linter** *with* or *without* your own persona
 If you need to disable certain *rules* and *functionality*, you can view [Disable Rules](https://github.com/github/super-linter/blob/master/docs/disabling-linters.md)
 
 ## Docker Hub
-The **Docker** container that is built from this repository is located at `https://hub.docker.com/r/admiralawkbar/super-linter`
+The **Docker** container that is built from this repository is located at `https://hub.docker.com/r/github/super-linter`
 
 ## Running Super-Linter locally (troubleshooting/debugging/enhancements)
 If you find that you need to run super-linter locally, you can follow the documentation at [Running super-linter locally](https://github.com/github/super-linter/blob/master/docs/run-linter-locally.md)

--- a/docs/run-linter-locally.md
+++ b/docs/run-linter-locally.md
@@ -12,13 +12,13 @@ You can follow the link below on how to install and configure **Docker** on your
 
 ## Download the latest Super-Linter Docker container
 - Pull the latest **Docker** container down from **DockerHub**
-  - `docker pull admiralawkbar/super-linter:latest`
+  - `docker pull github/super-linter:latest`
 Once the container has been downloaded to your local environment, you can then begin the process, or running the container against your codebase.
 
 ## Run the container Locally
 - You can run the container locally with the following **Base** flags to run your code:
-  - `docker run -e RUN_LOCAL=true -v /path/to/local/codebase:/tmp/lint admiralawkbar/super-linter`
-    - To run against a single file you can use: `docker run -e RUN_LOCAL=true -v /path/to/local/codebase/file:/tmp/lint/file admiralawkbar/super-linter`
+  - `docker run -e RUN_LOCAL=true -v /path/to/local/codebase:/tmp/lint github/super-linter`
+    - To run against a single file you can use: `docker run -e RUN_LOCAL=true -v /path/to/local/codebase/file:/tmp/lint/file github/super-linter`
   - **NOTE:** You need to pass the `RUN_LOCAL` flag to bypass some of the GitHub Actions checks, as well as the mapping of your local codebase to `/tmp/lint` so that the linter can pick up the code
   - **NOTE:** The flag:`RUN_LOCAL` will set: `VALIDATE_ALL_CODEBASE` to true. This means it will scan **all** the files in the directory you have mapped. If you want to only validate a subset of your codebase, map a folder with only the files you wish to have linted
 
@@ -29,7 +29,7 @@ You can add as many **Additional** flags as needed, documented in [README.md](..
 
 ### Run container and gain access to the command line
 If you need to run the container locally and gain access to its command line, you can run the following command:
-- `docker run -it --entrypoint /bin/bash admiralawkbar/super-linter`
+- `docker run -it --entrypoint /bin/bash github/super-linter`
 - This will drop you in the command line of the docker container for any testing or troubleshooting that may be needed.
 
 ### Found issues


### PR DESCRIPTION
Now that https://github.com/github/super-linter/pull/137 has been merged, we should start pointing to it as the official image. 

cc @admiralAwkbar 