### PR TITLE
Update to latest golangci-lint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/s
 #####################
 # Install Go Linter #
 #####################
-ARG GO_VERSION='v1.23.7'
+ARG GO_VERSION='v1.27.0'
 RUN wget -O- -nvq https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s "$GO_VERSION"
 
 ##################


### PR DESCRIPTION
In setting super-linter up on one of my repo's, I ran into
golangci/golangci-lint#827 which is apparently fixed in v1.23.8 (and has
improved error messages in v1.24.0). I'm not sure if there's a reason for
using the version that is there now, but if the latest doesn't work,
please at least update to 1.24.0.

Signed-off-by: iggy <iggy@theiggy.com>