### PR TITLE
Update the notation of RuboCop

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Developers on **GitHub** can call the **GitHub Action** to lint their code base 
 | **Markdown**     | [markdownlint](https://github.com/igorshubovych/markdownlint-cli#readme) |
 | **Perl**         | [perl](https://pkgs.alpinelinux.org/package/edge/main/x86/perl)          |
 | **Python3**      | [pylint](https://www.pylint.org/)                                        |
-| **Ruby**         | [Rubocop](https://github.com/rubocop-hq/rubocop)                         |
+| **Ruby**         | [RuboCop](https://github.com/rubocop-hq/rubocop)                         |
 | **Shell**        | [Shellcheck](https://github.com/koalaman/shellcheck)                     |
 | **Terraform**    | [tflint](https://github.com/terraform-linters/tflint)                    |
 | **TypeScript**   | [eslint](https://eslint.org/) [standard js](https://standardjs.com/)     |

--- a/docs/disabling-linters.md
+++ b/docs/disabling-linters.md
@@ -26,20 +26,20 @@ Below is examples and documentation for each language and the various methods to
 --------------------------------------------------------------------------------
 
 ## Ruby
-- [Rubocop](https://github.com/rubocop-hq/rubocop)
+- [RuboCop](https://github.com/rubocop-hq/rubocop)
 
-### Rubocop Config file
+### RuboCop Config file
 - `.github/linters/.ruby-lint.yml`
 - You can pass multiple rules and overwrite default rules
 - File should be located at: `.github/linters/.ruby-lint.yml`
-- **Note:** We use the Default **GitHub** Rule set from [Rubocop-GitHub](https://github.com/github/rubocop-github)
+- **Note:** We use the Default **GitHub** Rule set from [RuboCop-GitHub](https://github.com/github/rubocop-github)
 
-### Rubocop disable single line
+### RuboCop disable single line
 ```ruby
 method(argument) # rubocop:disable SomeRule, SomeOtherRule
 ```
 
-### Rubocop disable code block
+### RuboCop disable code block
 ```ruby
 # rubocop:disable
 This is a long line
@@ -47,7 +47,7 @@ var="this is some other stuff"
 # rubocop:enable
 ```
 
-### Rubocop disable entire file
+### RuboCop disable entire file
 If you need to ignore an entire file, you can update the `.github/linters/.ruby-lint.yml` to ignore certain files and locations
 
 ```yml


### PR DESCRIPTION
RuboCop is the proper notation as below.

> **RuboCop** is a Ruby static code analyzer (a.k.a. `linter`) and code formatter.

https://github.com/rubocop-hq/rubocop/blob/v0.85.1/README.md