### PR TITLE
Add dotenv-linter support to super-linter

### DIFF
--- a/.automation/test/env/README.md
+++ b/.automation/test/env/README.md
@@ -1,0 +1,13 @@
+# ENV Test Cases
+This folder holds the test cases for **ENV**.
+
+## Additional Docs
+No Additional information is needed for this test case.
+
+## Good Test Cases
+The test cases denoted: `LANGUAGE_good_FILE.EXTENSION` are all valid, and should pass successfully when linted.
+- **Note:** They are linted utilizing the default linter rules.
+
+## Bad Test Cases
+The test cases denoted: `LANGUAGE_bad_FILE.EXTENSION` are **NOT** valid, and should trigger errors when linted.
+- **Note:** They are linted utilizing the default linter rules.

--- a/.automation/test/env/env_bad_1.env
+++ b/.automation/test/env/env_bad_1.env
@@ -1,0 +1,5 @@
+ LOGGER_LEVEL=info
+MY_ENV
+DB-NAME=testing
+DEbUG_hTTP=true
+DB_NAME=development

--- a/.automation/test/env/env_good_1.env
+++ b/.automation/test/env/env_good_1.env
@@ -1,0 +1,4 @@
+DB_NAME=development
+DEBUG_HTTP=true
+LOGGER_LEVEL=info
+MY_ENV=

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,12 @@ RUN wget -O- -nvq https://raw.githubusercontent.com/golangci/golangci-lint/maste
 RUN curl -Ls "$(curl -Ls https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" -o tflint.zip && unzip tflint.zip && rm tflint.zip \
     && mv "tflint" /usr/bin/
 
+##################
+# Install dotenv-linter #
+##################
+RUN wget "https://github.com/dotenv-linter/dotenv-linter/releases/latest/download/dotenv-linter-alpine-x86_64.tar.gz" -O - -q | tar -xzf - \
+    && mv "dotenv-linter" /usr/bin
+
 ###########################################
 # Load GitHub Env Vars for GitHub Actions #
 ###########################################
@@ -128,6 +134,7 @@ ENV GITHUB_SHA=${GITHUB_SHA} \
     VALIDATE_GO=${VALIDATE_GO} \
     VALIDATE_TERRAFORM=${VALIDATE_TERRAFORM} \
     VALIDATE_CSS=${VALIDATE_CSS} \
+    VALIDATE_ENV=${VALIDATE_ENV} \
     ANSIBLE_DIRECTORY=${ANSIBLE_DIRECTORY} \
     RUN_LOCAL=${RUN_LOCAL} \
     TEST_CASE_RUN=${TEST_CASE_RUN} \

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Developers on **GitHub** can call the **GitHub Action** to lint their code base 
 | **TypeScript**   | [eslint](https://eslint.org/) [standard js](https://standardjs.com/)     |
 | **XML**          | [LibXML](http://xmlsoft.org/)                                            |
 | **YAML**         | [YamlLint](https://github.com/adrienverge/yamllint)                      |
+| **ENV**          | [dotenv-linter](https://github.com/dotenv-linter/dotenv-linter)          |
 
 ## How to use
 To use this **GitHub** Action you will need to complete the following:
@@ -135,6 +136,7 @@ and won't run anything unexpected.
 | **VALIDATE_GO** | `true` | Flag to enable or disable the linting process of the language. |
 | **VALIDATE_TERRAFORM** | `true` | Flag to enable or disable the linting process of the language. |
 | **VALIDATE_CSS** | `true` | Flag to enable or disable the linting process of the language. |
+| **VALIDATE_ENV** | `true` | Flag to enable or disable the linting process of the language. |
 | **ANSIBLE_DIRECTORY** | `/ansible` | Flag to set the root directory for Ansible file location(s). |
 | **ACTIONS_RUNNER_DEBUG** | `false` | Flag to enable additional information about the linter, versions, and additional output. |
 | **DEFAULT_WORKSPACE** | `/tmp/lint` | The location containing files to lint if you are running locally. |

--- a/docs/disabling-linters.md
+++ b/docs/disabling-linters.md
@@ -555,7 +555,7 @@ a {}
 - There is no top level *configuration file* available at this time
 
 ### dotenv-linter disable single line
-```
+```env
 # Comment line will be ignored
 ```
 

--- a/docs/disabling-linters.md
+++ b/docs/disabling-linters.md
@@ -21,6 +21,7 @@ Below is examples and documentation for each language and the various methods to
 - [Dockerfile](#dockerfile)
 - [Terraform](#terraform)
 - [CSS](#stylelint)
+- [ENV](#dotenv-linter)
 
 <!-- toc -->
 
@@ -544,3 +545,22 @@ a {}
    ]
 }
 ```
+
+--------------------------------------------------------------------------------
+
+## ENV
+- [dotenv-linter](https://github.com/dotenv-linter/dotenv-linter)
+
+### dotenv-linter Config file
+- There is no top level *configuration file* available at this time
+
+### dotenv-linter disable single line
+```
+# Comment line will be ignored
+```
+
+### dotenv-linter disable code block
+- There is currently **No** way to disable rules inline of the file(s)
+
+### dotenv-linter disable entire file
+- There is currently **No** way to disable rules inline of the file(s)

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -59,14 +59,14 @@ CSS_LINTER_RULES="$DEFAULT_RULES_LOCATION/$CSS_FILE_NAME"           # Path to th
 LINTER_ARRAY=("jsonlint" "yamllint" "xmllint" "markdownlint" "shellcheck"
   "pylint" "perl" "rubocop" "coffeelint" "eslint" "standard"
   "ansible-lint" "/dockerfilelint/bin/dockerfilelint" "golangci-lint" "tflint"
-  "stylelint")
+  "stylelint" "dotenv-linter")
 
 #############################
 # Language array for prints #
 #############################
 LANGUAGE_ARRAY=('YML' 'JSON' 'XML' 'MARKDOWN' 'BASH' 'PERL' 'RUBY' 'PYTHON'
   'COFFEESCRIPT' 'ANSIBLE' 'JAVASCRIPT_STANDARD' 'JAVASCRIPT_ES'
-  'TYPESCRIPT_STANDARD' 'TYPESCRIPT_ES' 'DOCKER' 'GO' 'TERRAFORM' 'CSS')
+  'TYPESCRIPT_STANDARD' 'TYPESCRIPT_ES' 'DOCKER' 'GO' 'TERRAFORM' 'CSS' "ENV")
 
 ###################
 # GitHub ENV Vars #
@@ -95,6 +95,7 @@ VALIDATE_DOCKER="${VALIDATE_DOCKER}"                  # Boolean to validate lang
 VALIDATE_GO="${VALIDATE_GO}"                          # Boolean to validate language
 VALIDATE_TERRAFORM="${VALIDATE_TERRAFORM}"            # Boolean to validate language
 VALIDATE_CSS="${VALIDATE_CSS}"                        # Boolean to validate language
+VALIDATE_ENV="${VALIDATE_ENV}"                        # Boolean to validate language
 TEST_CASE_RUN="${TEST_CASE_RUN}"                      # Boolean to validate only test cases
 
 ##############
@@ -136,6 +137,7 @@ FILE_ARRAY_DOCKER=()                # Array of files to check
 FILE_ARRAY_GO=()                    # Array of files to check
 FILE_ARRAY_TERRAFORM=()             # Array of files to check
 FILE_ARRAY_CSS=()                   # Array of files to check
+FILE_ARRAY_ENV=()                   # Array of files to check
 
 ############
 # Counters #
@@ -158,6 +160,7 @@ ERRORS_FOUND_DOCKER=0               # Count of errors found
 ERRORS_FOUND_GO=0                   # Count of errors found
 ERRORS_FOUND_TERRAFORM=0            # Count of errors found
 ERRORS_FOUND_CSS=0                  # Count of errors found
+ERRORS_FOUND_ENV=0                  # Count of errors found
 
 ################################################################################
 ########################## FUNCTIONS BELOW #####################################
@@ -735,6 +738,7 @@ GetValidationInfo()
   VALIDATE_GO=$(echo "$VALIDATE_GO" | awk '{print tolower($0)}')
   VALIDATE_TERRAFORM=$(echo "$VALIDATE_TERRAFORM" | awk '{print tolower($0)}')
   VALIDATE_CSS=$(echo "$VALIDATE_CSS" | awk '{print tolower($0)')
+  VALIDATE_ENV=$(echo "$VALIDATE_ENV" | awk '{print tolower($0)')
 
   ################################################
   # Determine if any linters were explicitly set #
@@ -757,7 +761,8 @@ GetValidationInfo()
         -n "$VALIDATE_DOCKER" || \
         -n "$VALIDATE_GO" || \
         -n "$VALIDATE_TERRAFORM" || \
-        -n "$VALIDATE_CSS" ]]; then
+        -n "$VALIDATE_CSS" || \
+        -n "$VALIDATE_ENV" ]]; then
     ANY_SET="true"
   fi
 
@@ -1013,6 +1018,20 @@ GetValidationInfo()
     VALIDATE_CSS="true"
   fi
 
+  ####################################
+  # Validate if we should check ENV #
+  ####################################
+  if [[ "$ANY_SET" == "true" ]]; then
+    # Some linter flags were set - only run those set to true
+    if [[ -z "$VALIDATE_ENV" ]]; then
+      # ENV flag was not set - default to false
+      VALIDATE_ENV="false"
+    fi
+  else
+    # No linter flags were set - default all to true
+    VALIDATE_ENV="true"
+  fi
+
   #######################################
   # Print which linters we are enabling #
   #######################################
@@ -1105,6 +1124,11 @@ GetValidationInfo()
     PRINT_ARRAY+=("- Validating [CSS] files in code base...")
   else
     PRINT_ARRAY+=("- Excluding [CSS] files in code base...")
+  fi
+  if [[ "$VALIDATE_ENV" == "true" ]]; then
+    PRINT_ARRAY+=("- Validating [ENV] files in code base...")
+  else
+    PRINT_ARRAY+=("- Excluding [ENV] files in code base...")
   fi
 
   ##############################
@@ -1418,6 +1442,15 @@ BuildFileList()
       # Append the file to the array #
       ################################
       FILE_ARRAY_CSS+=("$FILE")
+      ##########################################################
+      # Set the READ_ONLY_CHANGE_FLAG since this could be exec #
+      ##########################################################
+      READ_ONLY_CHANGE_FLAG=1
+    elif [ "$FILE_TYPE" == "env" ]; then
+      ################################
+      # Append the file to the array #
+      ################################
+      FILE_ARRAY_ENV+=("$FILE")
       ##########################################################
       # Set the READ_ONLY_CHANGE_FLAG since this could be exec #
       ##########################################################
@@ -1928,7 +1961,8 @@ Footer()
      [ "$ERRORS_FOUND_GO" -ne 0 ] || \
      [ "$ERRORS_FOUND_TERRAFORM" -ne 0 ] || \
      [ "$ERRORS_FOUND_RUBY" -ne 0 ] || \
-     [ "$ERRORS_FOUND_CSS" -ne 0 ]; then
+     [ "$ERRORS_FOUND_CSS" -ne 0 ] || \
+     [ "$ERRORS_FOUND_ENV" -ne 0 ]; then
     # Failed exit
     echo "Exiting with errors found!"
     exit 1
@@ -1986,6 +2020,7 @@ RunTestCases()
   TestCodebase "ANSIBLE" "ansible-lint" "ansible-lint -v -c $ANSIBLE_LINTER_RULES" "ansible-lint"
   TestCodebase "TERRAFORM" "tflint" "tflint -c $TERRAFORM_LINTER_RULES" ".*\.\(tf\)\$"
   TestCodebase "CSS" "stylelint" "stylelint --config $CSS_LINTER_RULES" ".*\.\(css\)\$"
+  TestCodebase "ENV" "dotenv-linter" "dotenv-linter" ".*\.\(env\)\$"
 
   #################
   # Footer prints #
@@ -2269,6 +2304,17 @@ if [ "$VALIDATE_CSS" == "true" ]; then
   # Lint the CSS files #
   #############################
   LintCodebase "CSS" "stylelint" "stylelint --config $CSS_LINTER_RULES" ".*\.\(css\)\$" "${FILE_ARRAY_CSS[@]}"
+fi
+
+################
+# ENV LINTING #
+################
+if [ "$VALIDATE_ENV" == "true" ]; then
+  #######################
+  # Lint the env files #
+  #######################
+  # LintCodebase "FILE_TYPE" "LINTER_NAME" "LINTER_CMD" "FILE_TYPES_REGEX" "FILE_ARRAY"
+  LintCodebase "ENV" "dotenv-linter" "dotenv-linter" ".*\.\(env\)\$" "${FILE_ARRAY_ENV[@]}"
 fi
 
 ##################


### PR DESCRIPTION
Added support for the linter for `.env` files (#173)  using the [dotenv-linter](https://github.com/dotenv-linter/dotenv-linter).
I also added files for tests.