### PR TITLE
The word "disable" was misspelled

### DIFF
--- a/TEMPLATES/.yaml-lint.yml
+++ b/TEMPLATES/.yaml-lint.yml
@@ -3,7 +3,7 @@
 # These are the rules used for            #
 # linting all the yaml files in the stack #
 # NOTE:                                   #
-# You can disble line with:               #
+# You can disable line with:              #
 # # yamllint disable-line                 #
 ###########################################
 rules:


### PR DESCRIPTION
This is a very minor change. Just fixes a spelling in the yaml file. 