### PR TITLE
Add support more variants names of env files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,9 +102,9 @@ RUN wget -O- -nvq https://raw.githubusercontent.com/golangci/golangci-lint/maste
 RUN curl -Ls "$(curl -Ls https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" -o tflint.zip && unzip tflint.zip && rm tflint.zip \
     && mv "tflint" /usr/bin/
 
-##################
+#########################
 # Install dotenv-linter #
-##################
+#########################
 RUN wget "https://github.com/dotenv-linter/dotenv-linter/releases/latest/download/dotenv-linter-alpine-x86_64.tar.gz" -O - -q | tar -xzf - \
     && mv "dotenv-linter" /usr/bin
 

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -1020,9 +1020,9 @@ GetValidationInfo()
     VALIDATE_CSS="true"
   fi
 
-  ####################################
+  ###################################
   # Validate if we should check ENV #
-  ####################################
+  ###################################
   if [[ "$ANY_SET" == "true" ]]; then
     # Some linter flags were set - only run those set to true
     if [[ -z "$VALIDATE_ENV" ]]; then
@@ -2050,7 +2050,7 @@ RunTestCases()
   TestCodebase "ANSIBLE" "ansible-lint" "ansible-lint -v -c $ANSIBLE_LINTER_RULES" "ansible-lint"
   TestCodebase "TERRAFORM" "tflint" "tflint -c $TERRAFORM_LINTER_RULES" ".*\.\(tf\)\$"
   TestCodebase "CSS" "stylelint" "stylelint --config $CSS_LINTER_RULES" ".*\.\(css\)\$"
-  TestCodebase "ENV" "dotenv-linter" "dotenv-linter" ".*\.\(env\)\$"
+  TestCodebase "ENV" "dotenv-linter" "dotenv-linter" ".*\.\(env\).*\$"
 
   #################
   # Footer prints #
@@ -2336,15 +2336,15 @@ if [ "$VALIDATE_CSS" == "true" ]; then
   LintCodebase "CSS" "stylelint" "stylelint --config $CSS_LINTER_RULES" ".*\.\(css\)\$" "${FILE_ARRAY_CSS[@]}"
 fi
 
-################
+###############
 # ENV LINTING #
-################
+###############
 if [ "$VALIDATE_ENV" == "true" ]; then
   #######################
   # Lint the env files #
   #######################
   # LintCodebase "FILE_TYPE" "LINTER_NAME" "LINTER_CMD" "FILE_TYPES_REGEX" "FILE_ARRAY"
-  LintCodebase "ENV" "dotenv-linter" "dotenv-linter" ".*\.\(env\)\$" "${FILE_ARRAY_ENV[@]}"
+  LintCodebase "ENV" "dotenv-linter" "dotenv-linter" ".*\.\(env\).*\$" "${FILE_ARRAY_ENV[@]}"
 fi
 
 ##################


### PR DESCRIPTION
Hi there!

Right now, super-linter finds only these variants of `env` files:
```
foo.env
.env
```

In this PR I add support for additional variants:
```
.env.foo
.env.foo.example
```