### PR TITLE
Update anchor for both CSS and Env linter in the table of content

### DIFF
--- a/docs/disabling-linters.md
+++ b/docs/disabling-linters.md
@@ -20,8 +20,8 @@ Below is examples and documentation for each language and the various methods to
 - [Golang](#golang)
 - [Dockerfile](#dockerfile)
 - [Terraform](#terraform)
-- [CSS](#stylelint)
-- [ENV](#dotenv-linter)
+- [CSS](#css)
+- [ENV](#env)
 
 <!-- toc -->
 


### PR DESCRIPTION
Update documentation part "**Disabling linters and Rules**".

Some anchors doesn't work.

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>