### PR TITLE
Turn the pipe operator into the proper or operator

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -223,7 +223,7 @@ GetLinterVersions()
     ##############################
     # Check the shell for errors #
     ##############################
-    if [ $ERROR_CODE -ne 0 ] | [ -z "${GET_VERSION_CMD[*]}" ]; then
+    if [ $ERROR_CODE -ne 0 ] || [ -z "${GET_VERSION_CMD[*]}" ]; then
       echo "WARN! Failed to get version info for:[$LINTER]"
       echo "---------------------------------------------"
     else


### PR DESCRIPTION
Currently the `linter.sh` file uses:

```
    if [ $ERROR_CODE -ne 0 ] | [ -z "${GET_VERSION_CMD[*]}" ]; then
```

which is effectively `test | test`. This will cause the first `test` to be ignored, and only the second test's exit status will be considered. This changes it to `test || test` where it considers both