### PR TITLE
Adding Rust support via Clippy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,12 @@ RUN curl -Ls "$(curl -Ls https://api.github.com/repos/terraform-linters/tflint/r
 RUN wget "https://github.com/dotenv-linter/dotenv-linter/releases/latest/download/dotenv-linter-alpine-x86_64.tar.gz" -O - -q | tar -xzf - \
     && mv "dotenv-linter" /usr/bin
 
+#######################
+# Install Rust Linter #
+#######################
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && rustup component add clippy
+
 ###########################################
 # Load GitHub Env Vars for GitHub Actions #
 ###########################################
@@ -124,6 +130,7 @@ ENV GITHUB_SHA=${GITHUB_SHA} \
     VALIDATE_PERL=${VALIDATE_PERL} \
     VALIDATE_PYTHON=${VALIDATE_PYTHON} \
     VALIDATE_RUBY=${VALIDATE_RUBY} \
+    VALIDATE_RUST=${VALIDATE_RUST} \
     VALIDATE_COFFEE=${VALIDATE_COFFEE} \
     VALIDATE_ANSIBLE=${VALIDATE_ANSIBLE} \
     VALIDATE_DOCKER=${VALIDATE_DOCKER} \

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Developers on **GitHub** can call the **GitHub Action** to lint their code base 
 | **Perl**         | [perl](https://pkgs.alpinelinux.org/package/edge/main/x86/perl)          |
 | **Python3**      | [pylint](https://www.pylint.org/)                                        |
 | **Ruby**         | [RuboCop](https://github.com/rubocop-hq/rubocop)                         |
+| **Rust**         | [Clippy](https://github.com/rust-lang/rust-clippy)                       |
 | **Shell**        | [Shellcheck](https://github.com/koalaman/shellcheck)                     |
 | **Terraform**    | [tflint](https://github.com/terraform-linters/tflint)                    |
 | **TypeScript**   | [eslint](https://eslint.org/) [standard js](https://standardjs.com/)     |
@@ -126,6 +127,7 @@ and won't run anything unexpected.
 | **VALIDATE_PERL** | `true` | Flag to enable or disable the linting process of the language. |
 | **VALIDATE_PYTHON** | `true` | Flag to enable or disable the linting process of the language. |
 | **VALIDATE_RUBY** | `true` | Flag to enable or disable the linting process of the language. |
+| **VALIDATE_RUST** | `true` | Flag to enable or disable the linting process of the language. |
 | **VALIDATE_COFFEE** | `true` | Flag to enable or disable the linting process of the language . |
 | **VALIDATE_ANSIBLE** | `true` | Flag to enable or disable the linting process of the language. |
 | **VALIDATE_JAVASCRIPT_ES** | `true` | Flag to enable or disable the linting process of the language. (Utilizing: eslint) |


### PR DESCRIPTION
Resolves #108 

Questions...
- This currently defaults to the latest version `rustup` installs. Should it be hard coded to a specific version?
- `clippy` has some support for [configuration files](https://github.com/rust-lang/rust-clippy#configuration) but it looks like they need to be included in the Rust project itself, not passed in as arguments to `clippy`. I wasn't sure how or if I should try to add these config files to the super linters config file setup.