### PR TITLE
Point linter.yml example to existing version

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: docker://github/super-linter:v2.1.1
+        uses: docker://github/super-linter:v2.1.0
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_ANSIBLE: false


### PR DESCRIPTION
The current example is not pointing to the latest version but one which doesn't exists right now.
This can cause users to run into errors.