### PR TITLE
Fix Typo

### DIFF
--- a/TEMPLATES/.ansible-lint.yml
+++ b/TEMPLATES/.ansible-lint.yml
@@ -29,9 +29,9 @@ quiet: true
 ################
 skip_list:
   - '602' # Allow compare to empty string
-  - '204' # Allow string length greater that 160 chars
+  - '204' # Allow string length greater than 160 chars
   - '301' # False positives for running command shells
-  - '303' # Allow git commands for push add, etc...
+  - '303' # Allow git commands for push, add, etc...
   - '305' # Allow use of shell when you want
   - '503' # Allow step to run like handler
 

--- a/docs/disabling-linters.md
+++ b/docs/disabling-linters.md
@@ -1,7 +1,7 @@
 # Disabling linters and Rules
 If you find you need to ignore certain **errors** and **warnings**, you will need to know the *format* to disable the **Super-Linter** rules.  
 Below is examples and documentation for each language and the various methods to disable.
-
+Below are examples and documentation for each language and  various methods to disable.
 ## Table of Linters
 - [Ruby](#ruby)
 - [Shell](#shell)

--- a/docs/disabling-linters.md
+++ b/docs/disabling-linters.md
@@ -1,6 +1,6 @@
 # Disabling linters and Rules
 If you find you need to ignore certain **errors** and **warnings**, you will need to know the *format* to disable the **Super-Linter** rules.  
-Below is examples and documentation for each language and the various methods to disable.
+Below are examples and documentation for each language and the various methods to disable.
 
 ## Table of Linters
 - [Ruby](#ruby)

--- a/docs/disabling-linters.md
+++ b/docs/disabling-linters.md
@@ -1,7 +1,7 @@
 # Disabling linters and Rules
 If you find you need to ignore certain **errors** and **warnings**, you will need to know the *format* to disable the **Super-Linter** rules.  
 Below is examples and documentation for each language and the various methods to disable.
-Below are examples and documentation for each language and  various methods to disable.
+
 ## Table of Linters
 - [Ruby](#ruby)
 - [Shell](#shell)


### PR DESCRIPTION
In .ansible-lint.yml fixed a typo of that to then and added a comma between push and add.