### PR TITLE
Add disclaimer about local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The end goal of this tool:
 
 The super-linter finds issues and reports them to the console output. Fixes are suggested in the console output but not automatically fixed, and a status check will show up as failed on the pull request.
 
+The design of the **Super-Linter** is currently to allow linting to occur in **GitHub Actions** as a part of continuous integration occurring on pull requests as the commits get pushed. It works best when commits are being pushed early and often to a branch with an open or draft pull request. There is some desire to move this closer to local development for faster feedback on linting errors but this is not yet supported.
+
 ## Supported Linters
 
 Developers on **GitHub** can call the **GitHub Action** to lint their code base with the following list of linters:
@@ -162,6 +164,8 @@ The **Docker** container that is built from this repository is located at `https
 
 ## Running Super-Linter locally (troubleshooting/debugging/enhancements)
 If you find that you need to run super-linter locally, you can follow the documentation at [Running super-linter locally](https://github.com/github/super-linter/blob/master/docs/run-linter-locally.md)
+
+Check out the [note](#how-it-works) in **How it Works** to understand more about the **Super-Linter** linting locally versus via continuous integration.
 
 ### CI/CT/CD
 The **Super-Linter** has *CI/CT/CD* configured utilizing **GitHub** Actions.


### PR DESCRIPTION
This addition to the `README.md` is to help clarify incoming requests about why run linting at the time of pull request (ci) instead of at the time of code writing (local).

closes https://github.com/github/super-linter/issues/204