### PR TITLE
Add JAVASCRIPT_ES_CONFIG_FILE to specify eslintrc filename / format

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ and won't run anything unexpected.
 | **VALIDATE_COFFEE** | `true` | Flag to enable or disable the linting process of the language . |
 | **VALIDATE_ANSIBLE** | `true` | Flag to enable or disable the linting process of the language. |
 | **VALIDATE_JAVASCRIPT_ES** | `true` | Flag to enable or disable the linting process of the language. (Utilizing: eslint) |
+| **JAVASCRIPT_ES_CONFIG_FILE** | `.eslintrc.yml` | Filename for [eslint configuration](https://eslint.org/docs/user-guide/configuring#configuration-file-formats) (ex: `.eslintrc.yml`, `.eslintrc.json`)|
 | **VALIDATE_JAVASCRIPT_STANDARD** | `true` | Flag to enable or disable the linting process of the language. (Utilizing: standard) |
 | **VALIDATE_TYPESCRIPT_ES** | `true` | Flag to enable or disable the linting process of the language. (Utilizing: eslint) |
 | **VALIDATE_TYPESCRIPT_STANDARD** | `true` | Flag to enable or disable the linting process of the language. (Utilizing: standard) |

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -92,6 +92,7 @@ VALIDATE_RUBY="${VALIDATE_RUBY}"                      # Boolean to validate lang
 VALIDATE_COFFEE="${VALIDATE_COFFEE}"                  # Boolean to validate language
 VALIDATE_ANSIBLE="${VALIDATE_ANSIBLE}"                # Boolean to validate language
 VALIDATE_JAVASCRIPT_ES="${VALIDATE_JAVASCRIPT_ES}"              # Boolean to validate language
+JAVASCRIPT_ES_CONFIG_FILE="${JAVASCRIPT_ES_CONFIG_FILE}"              # Filename for eslint configuration (ex: .eslintrc.yml, .eslintrc.json)
 VALIDATE_JAVASCRIPT_STANDARD="${VALIDATE_JAVASCRIPT_STANDARD}"  # Boolean to validate language
 VALIDATE_TYPESCRIPT_ES="${VALIDATE_TYPESCRIPT_ES}"              # Boolean to validate language
 VALIDATE_TYPESCRIPT_STANDARD="${VALIDATE_TYPESCRIPT_STANDARD}"  # Boolean to validate language
@@ -117,6 +118,7 @@ ACTIONS_RUNNER_DEBUG="${ACTIONS_RUNNER_DEBUG}"  # Boolean to see even more info 
 DEFAULT_VALIDATE_ALL_CODEBASE='true'                    # Default value for validate all files
 DEFAULT_WORKSPACE="${DEFAULT_WORKSPACE:-/tmp/lint}"     # Default workspace if running locally
 DEFAULT_ANSIBLE_DIRECTORY="$GITHUB_WORKSPACE/ansible"   # Default Ansible Directory
+DEFAULT_JAVASCRIPT_ES_CONFIG_FILE=".eslintrc.yml"       # Default eslint configuration filename
 DEFAULT_RUN_LOCAL='false'             # Default value for debugging locally
 DEFAULT_TEST_CASE_RUN='false'         # Flag to tell code to run only test cases
 DEFAULT_ACTIONS_RUNNER_DEBUG='false'  # Default value for debugging output
@@ -1226,6 +1228,19 @@ GetValidationInfo()
     # Set the value
     ANSIBLE_DIRECTORY="$TEMP_ANSIBLE_DIRECTORY"
   fi
+	
+  #########################################
+  # Get the eslint configuration filename #
+  #########################################
+  if [ -z "$JAVASCRIPT_ES_CONFIG_FILE" ]; then
+    ######################################
+    # No filename passed, set to default #
+    ######################################
+    JAVASCRIPT_ES_CONFIG_FILE="$DEFAULT_JAVASCRIPT_ES_CONFIG_FILE"
+  fi
+  # Set Javascript Vars based on JAVASCRIPT_ES_CONFIG_FILE
+  JAVASCRIPT_FILE_NAME='$JAVASCRIPT_ES_CONFIG_FILE'                       # Name of the file
+  JAVASCRIPT_LINTER_RULES="$DEFAULT_RULES_LOCATION/$JAVASCRIPT_FILE_NAME" # Path to the Javascript lint rules
 
   ###############################
   # Get the disable errors flag #


### PR DESCRIPTION
See: https://eslint.org/docs/user-guide/configuring#configuration-file-formats

ESLint supports many different configuration filenames and formats. This PR adds a new ENV variable `JAVASCRIPT_ES_CONFIG_FILE` (which defaults to the previous fixed `.eslintrc.yml`) to support specifying which file to use.

(In our case, we use `.eslintrc.json`)