### PR TITLE
Fix honoring pylint config file

### DIFF
--- a/.github/linters/.python-lint
+++ b/.github/linters/.python-lint
@@ -1,4 +1,5 @@
 [MASTER]
+errors-only=
 
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
@@ -157,7 +158,7 @@ output-format=text
 reports=no
 
 # Activate the evaluation score.
-score=yes
+score=no
 
 
 [REFACTORING]

--- a/TEMPLATES/.python-lint
+++ b/TEMPLATES/.python-lint
@@ -1,4 +1,5 @@
 [MASTER]
+errors-only=
 
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
@@ -157,7 +158,7 @@ output-format=text
 reports=no
 
 # Activate the evaluation score.
-score=yes
+score=no
 
 
 [REFACTORING]

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -2300,7 +2300,7 @@ RunTestCases()
   TestCodebase "XML" "xmllint" "xmllint" ".*\.\(xml\)\$"
   TestCodebase "MARKDOWN" "markdownlint" "markdownlint -c $MD_LINTER_RULES" ".*\.\(md\)\$"
   TestCodebase "BASH" "shellcheck" "shellcheck" ".*\.\(sh\)\$"
-  TestCodebase "PYTHON" "pylint" "pylint --rcfile $PYTHON_LINTER_RULES -E" ".*\.\(py\)\$"
+  TestCodebase "PYTHON" "pylint" "pylint --rcfile $PYTHON_LINTER_RULES" ".*\.\(py\)\$"
   TestCodebase "PERL" "perl" "perl -Mstrict -cw" ".*\.\(pl\)\$"
   TestCodebase "PHP" "php" "php -l" ".*\.\(php\)\$"
   TestCodebase "RUBY" "rubocop" "rubocop -c $RUBY_LINTER_RULES" ".*\.\(rb\)\$"
@@ -2472,7 +2472,7 @@ if [ "$VALIDATE_PYTHON" == "true" ]; then
   # Lint the python files #
   #########################
   # LintCodebase "FILE_TYPE" "LINTER_NAME" "LINTER_CMD" "FILE_TYPES_REGEX" "FILE_ARRAY"
-  LintCodebase "PYTHON" "pylint" "pylint --rcfile $PYTHON_LINTER_RULES -E" ".*\.\(py\)\$" "${FILE_ARRAY_PYTHON[@]}"
+  LintCodebase "PYTHON" "pylint" "pylint --rcfile $PYTHON_LINTER_RULES" ".*\.\(py\)\$" "${FILE_ARRAY_PYTHON[@]}"
 fi
 
 ################


### PR DESCRIPTION
The pylint config file is correctly being applied to
the pylint command, however, the `-E` flag is actually
not honoring any of the disabled messages in the
`.python-lint` file. By making this change to the
default lint file only the errors are output as expected
but honoring the disabled messages

For testing I did, see this gist: https://gist.github.com/dsayling/950a128dd771a11d0663c5bf63ea4ad3 

