### PR TITLE
Read Clojure filetypes from $FILE_TYPE, not $FILE

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -1695,7 +1695,7 @@ BuildFileList()
       # Set the READ_ONLY_CHANGE_FLAG since this could be exec #
       ##########################################################
       READ_ONLY_CHANGE_FLAG=1
-    elif [ "$FILE" == "clj" ] || [ "$FILE" == "cljs" ] || [ "$FILE" == "cljc" ] || [ "$FILE" == "edn" ]; then
+    elif [ "$FILE_TYPE" == "clj" ] || [ "$FILE_TYPE" == "cljs" ] || [ "$FILE_TYPE" == "cljc" ] || [ "$FILE_TYPE" == "edn" ]; then
       ################################
       # Append the file to the array #
       ################################


### PR DESCRIPTION
`super-linter` would previously attempt to compare Clojure file endings (such as `.clj` and `.cljc`) to `$FILE`, not `$FILE_TYPE`.

When running with `VALIDATE_CLOJURE: true` for a repo containing Clojure code, this would result in warnings like these in the linting output:
```
  - WARN! 
Failed to get filetype for:[project/src/my_ns.clj]!
```
And no validation of the mentioned Clojure files.

This closes #300