### PR TITLE
Add actions-tagger workflow to automate version tags

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,15 @@
+name: Keep the versions up-to-date
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  actions-tagger:
+    runs-on: windows-latest
+    steps:
+      - uses: Actions-R-Us/actions-tagger@latest
+        env:
+          GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"
+        with:
+          - publish_latest_tag: true


### PR DESCRIPTION
This closes #295 by automating the creation major version tags (i.e. `v2` to point to the latest minor version of `v2.*.*`) by leveraging a new workflow file, `versioning.yml`, that uses the [actions-tagger](https://github.com/marketplace/actions/actions-tagger) action.

The end result should be that we have a latest tag and a major tag pointing to the latest release sha.