### PR TITLE
Fix checkout action version

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
       ################################
       # Run Linter against code base #


### PR DESCRIPTION
When super-linter was updated to v3, the checkout action was also (accidentally) updated to v3.
v3 of the checkout action doesn't work.