### PR TITLE
Fix CSS link

### DIFF
--- a/docs/disabling-linters.md
+++ b/docs/disabling-linters.md
@@ -22,7 +22,7 @@ Below are examples and documentation for each language and the various methods t
 - [Golang](#golang)
 - [Dockerfile](#dockerfile)
 - [Terraform](#terraform)
-- [CSS](#stylelint)
+- [CSS](#css)
 - [ENV](#dotenv-linter)
 - [Kotlin](#kotlin)
 - [OpenAPI](#openapi)


### PR DESCRIPTION
The CSS link in the [disabling-linters page](https://github.com/github/super-linter/blob/master/docs/disabling-linters.md#table-of-linters) doesn't work so this PR fixes that.