### PR TITLE
Auto draft releases

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Draft pull requests are also welcome to get feedback early on, or if there is so
 ## Releasing
 If you are the current maintainer of this action:
 1. If a major version number change: Update `README.md` and the wiki to reflect new version number in the example workflow file sections
-2. Draft [Release](https://help.github.com/en/github/administering-a-repository/managing-releases-in-a-repository) with a summarized changelog
+2. Draft [Releases](https://help.github.com/en/github/administering-a-repository/managing-releases-in-a-repository) are created automatically. They just need to be checked over for accuracy before making it official.
 3. Ensure you check the box for [publishing to the marketplace](https://help.github.com/en/actions/creating-actions/publishing-actions-in-github-marketplace#publishing-an-action)
 4. A GitHub Action will Publish the Docker image to GitHub Package Registry once a Release is created
 5. A GitHub Action will Publish the Docker image to Docker Hub once a Release is created

--- a/.github/pull_request-template.md
+++ b/.github/pull_request-template.md
@@ -1,0 +1,13 @@
+<!-- Link to issue if there is one -->
+Fixes #
+
+<!-- Describe what the changes are -->
+## Proposed Changes
+
+  -
+  -
+  -
+
+## Readiness Checklist
+ - [ ] Label as `breaking` if this is a large fundamental change
+ - [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`

--- a/.github/pull_request-template.md
+++ b/.github/pull_request-template.md
@@ -1,4 +1,4 @@
-<!-- Please ensure your PR title is breif and descriptive for a good changelog entry -->
+<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
 <!-- Link to issue if there is one -->
 <!-- markdownlint-disable -->
 Fixes #

--- a/.github/pull_request-template.md
+++ b/.github/pull_request-template.md
@@ -1,13 +1,16 @@
+<!-- Please ensure your PR title is breif and descriptive for a good changelog entry -->
 <!-- Link to issue if there is one -->
+<!-- markdownlint-disable -->
 Fixes #
+<!-- markdownlint-restore -->
 
 <!-- Describe what the changes are -->
 ## Proposed Changes
 
-  -
-  -
-  -
+-
+-
+-
 
 ## Readiness Checklist
- - [ ] Label as `breaking` if this is a large fundamental change
- - [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
+- [ ] Label as `breaking` if this is a large fundamental change
+- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,39 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+template: |
+  # Changelog
+  $CHANGES
+  
+  See details of [all code changes](https://github.com/github/super-linter/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since last release 
+  
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'infrastructure'
+      - 'automation'
+      - 'documentation'
+  - title: '🏎 Performance'
+    label: 'performance'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+version-resolver:
+  major:
+    labels:
+      - 'type: breaking'
+  minor:
+    labels:
+      - 'type: enhancement'
+  patch:
+    labels:
+      - 'type: bug'
+      - 'type: maintenance'
+      - 'type: documentation'
+  default: patch

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
fixes #203 

- Adds the release drafter action, configured to attempt to guess the next version number
- Updates documentation to request labels on all pull requests before merge

Preview of what a draft release will look like:
**Note that where it says @zkoppert, it will put the author of the change
<img width="914" alt="Screen Shot 2020-07-01 at 9 08 51 PM" src="https://user-images.githubusercontent.com/6935431/86315466-130de400-bbdf-11ea-9bf5-b19497b42d7d.png">
