### PR TITLE
Use a global scope when setting the LANGAUGE_LINTER_RULES variable

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -317,7 +317,7 @@ GetLinterRules()
     ########################################
     # Update the path to the file location #
     ########################################
-    declare "${LANGUAGE_LINTER_RULES}=$GITHUB_WORKSPACE/$LINTER_RULES_PATH/${!LANGUAGE_FILE_NAME}"
+    declare -g "${LANGUAGE_LINTER_RULES}=$GITHUB_WORKSPACE/$LINTER_RULES_PATH/${!LANGUAGE_FILE_NAME}"
   else
     ########################################################
     # No user default provided, using the template default #


### PR DESCRIPTION
This PR changes the scope for the $LANGUAGE_LINTER_RULES variable so that it is seen when executing the `LintCodebase` function. Without this, the variable isn't changed outside of the `GetLinterRules` scope and therefore the default rules are applied.

Addresses the following issue: https://github.com/github/super-linter/issues/356
Possibly addresses this issue: https://github.com/github/super-linter/issues/234