### PR TITLE
docker should be checked in lower as it was converted

### DIFF
--- a/lib/buildFileList.sh
+++ b/lib/buildFileList.sh
@@ -344,7 +344,7 @@ function BuildFileList()
       # Set the READ_ONLY_CHANGE_FLAG since this could be exec #
       ##########################################################
       READ_ONLY_CHANGE_FLAG=1
-    elif [ "$FILE" == "Dockerfile" ]; then
+    elif [ "$FILE" == "dockerfile" ]; then
       ################################
       # Append the file to the array #
       ################################


### PR DESCRIPTION
This fixes a bug in the way we are normalizing file names during processing.