### PR TITLE
Fix GO linting

### DIFF
--- a/lib/buildFileList.sh
+++ b/lib/buildFileList.sh
@@ -281,7 +281,7 @@ function BuildFileList() {
       ################################
       # Append the file to the array #
       ################################
-      FILE_ARRAY_GO+=("$FILE")
+        FILE_ARRAY_GO+=("$(dirname "${FILE}")" )
       ##########################################################
       # Set the READ_ONLY_CHANGE_FLAG since this could be exec #
       ##########################################################
@@ -414,6 +414,9 @@ function BuildFileList() {
   done
 
   echo ${READ_ONLY_CHANGE_FLAG} > /dev/null 2>&1 || true # Workaround SC2034
+
+  FILE_ARRAY_GO=($(echo "${FILE_ARRAY_GO[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+
 
   #########################################
   # Need to switch back to branch of code #

--- a/lib/buildFileList.sh
+++ b/lib/buildFileList.sh
@@ -281,7 +281,7 @@ function BuildFileList() {
       ################################
       # Append the file to the array #
       ################################
-        FILE_ARRAY_GO+=("$(dirname "${FILE}")" )
+      FILE_ARRAY_GO+=("$(dirname "${FILE}")" )
       ##########################################################
       # Set the READ_ONLY_CHANGE_FLAG since this could be exec #
       ##########################################################

--- a/lib/buildFileList.sh
+++ b/lib/buildFileList.sh
@@ -415,8 +415,7 @@ function BuildFileList() {
 
   echo ${READ_ONLY_CHANGE_FLAG} > /dev/null 2>&1 || true # Workaround SC2034
 
-  FILE_ARRAY_GO=($(echo "${FILE_ARRAY_GO[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
-
+  mapfile -t FILE_ARRAY_GO < <(printf '%s\n' "${FILE_ARRAY_GO[@]}" | sort -u)
 
   #########################################
   # Need to switch back to branch of code #

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -955,8 +955,12 @@ if [ "$VALIDATE_GO" == "true" ]; then
   #########################
   # Lint the golang files #
   #########################
-  # LintCodebase "FILE_TYPE" "LINTER_NAME" "LINTER_CMD" "FILE_TYPES_REGEX" "FILE_ARRAY"
-  LintCodebase "GO" "golangci-lint" "golangci-lint run -c $GO_LINTER_RULES" ".*\.\(go\)\$" "${FILE_ARRAY_GO[@]}"
+    # LintCodebase "FILE_TYPE" "LINTER_NAME" "LINTER_CMD" "FILE_TYPES_REGEX" "FILE_ARRAY"
+    if [ "$VALIDATE_ALL_CODEBASE" == "true" ]; then
+        LintCodebase "GO" "golangci-lint" "golangci-lint run -c $GO_LINTER_RULES" ".*\.\(go\)\$" "$GITHUB_WORKSPACE/..."
+    else
+        LintCodebase "GO" "golangci-lint" "golangci-lint run -c $GO_LINTER_RULES" ".*\.\(go\)\$" "${FILE_ARRAY_GO[@]}"
+    fi
 fi
 
 #####################

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -955,12 +955,12 @@ if [ "$VALIDATE_GO" == "true" ]; then
   #########################
   # Lint the golang files #
   #########################
-    # LintCodebase "FILE_TYPE" "LINTER_NAME" "LINTER_CMD" "FILE_TYPES_REGEX" "FILE_ARRAY"
-    if [ "$VALIDATE_ALL_CODEBASE" == "true" ]; then
-        LintCodebase "GO" "golangci-lint" "golangci-lint run -c $GO_LINTER_RULES" ".*\.\(go\)\$" "$GITHUB_WORKSPACE/..."
-    else
-        LintCodebase "GO" "golangci-lint" "golangci-lint run -c $GO_LINTER_RULES" ".*\.\(go\)\$" "${FILE_ARRAY_GO[@]}"
-    fi
+  # LintCodebase "FILE_TYPE" "LINTER_NAME" "LINTER_CMD" "FILE_TYPES_REGEX" "FILE_ARRAY"
+  if [ "$VALIDATE_ALL_CODEBASE" == "true" ]; then
+      LintCodebase "GO" "golangci-lint" "golangci-lint run -c $GO_LINTER_RULES" ".*\.\(go\)\$" "$GITHUB_WORKSPACE/..."
+  else
+      LintCodebase "GO" "golangci-lint" "golangci-lint run -c $GO_LINTER_RULES" ".*\.\(go\)\$" "${FILE_ARRAY_GO[@]}"
+  fi
 fi
 
 #####################


### PR DESCRIPTION
As pointed out in #143, running super-linter on Golang code breaks as soon as packages are split in more than one files, which can happen even with moderately simple projects. The idea in this PR is to fix this issue by running `golangci-lint` on whole directories instead of singular files, when `VALIDATE_ALL_CODEBASE == false` and recursively on the whole repo otherwise.

Feedback is greatly appreciated on all points, but especially on the following:

- The array of go files to analyze will potentially contain multiple repeated entries. To get rid of them I am using the following commnad: `  mapfile -t FILE_ARRAY_GO < <(printf '%s\n' "${FILE_ARRAY_GO[@]}" | sort -u)` Any suggestion on better approaches from more experienced bash developers is highly appreciated.
- With this solution, the number of errors reported by SuperLinter will be always heavily underestimated. If running against all codebase, it will at most be 1; otherwise, it will be at most 1 for every directory analysed. Please note that, however, at the moment the number of errors is already not exactly the number of errors found by the linter but only the number of files with one or more errors (example [here](https://github.com/bznein/AoC2019-Go/runs/834384999?check_suite_focus=true) when the number of errors is equal to 1 while there are 3 errors in a single file)

A Docker image built from the code in this PR is available at https://hub.docker.com/r/bznein/superlinter