### PR TITLE
Fixed config load issue caused by quotes

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -336,7 +336,7 @@ GetLinterRules() {
     ########################################
     # Update the path to the file location #
     ########################################
-    declare -g "${LANGUAGE_LINTER_RULES}=$GITHUB_WORKSPACE/$LINTER_RULES_PATH/${!LANGUAGE_FILE_NAME}"
+    eval "${LANGUAGE_LINTER_RULES}=$GITHUB_WORKSPACE/$LINTER_RULES_PATH/${!LANGUAGE_FILE_NAME}"
   else
     ########################################################
     # No user default provided, using the template default #


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->
Fixes #368
<!-- markdownlint-restore -->

<!-- Describe what the changes are -->
## Proposed Changes

- Removed quotes surrounding declare causing variable to not read in correctly


## Readiness Checklist
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
