### PR TITLE
docs: correct name for markdown-lint

### DIFF
--- a/docs/disabling-linters.md
+++ b/docs/disabling-linters.md
@@ -310,9 +310,8 @@ ignore_templates:
 - [markdownlint inline comment syntax](https://github.com/DavidAnson/markdownlint#configuration)
 
 ### markdownlint Config file
-- `.github/linters/.markdown-lint.yml`
 - You can pass multiple rules and overwrite default rules
-- File should be located at: `.github/linters/.markdownlint.yml`
+- File should be located at: `.github/linters/.markdown-lint.yml`
 
 ### markdownlint disable single line
 ```markdown


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->
Fixes #
<!-- markdownlint-restore -->

<!-- Describe what the changes are -->
## Proposed Changes

minor fix for the docs to point at the correct filename for `.markdown-lint.yml`

## Readiness Checklist
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
