### PR TITLE
Added check to ensure volume is directory

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -597,6 +597,11 @@ GetGitHubVars() {
       GITHUB_WORKSPACE="$DEFAULT_WORKSPACE"
     fi
 
+    if [ ! -d "$GITHUB_WORKSPACE" ]; then
+      echo -e "${NC}${B[R]}${F[W]}ERROR:${NC} Provided volume is not a directory!${NC}"
+      exit 1
+    fi
+
     echo "Linting all files in mapped directory:[$DEFAULT_WORKSPACE]"
 
     # No need to touch or set the GITHUB_SHA


### PR DESCRIPTION
ADDED - Present user with error when attempting to pass non-directory as volume

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->
Fixes #362 
<!-- markdownlint-restore -->

<!-- Describe what the changes are -->
## Proposed Changes

- Provide user with error message when mounting non-directory volume

## Readiness Checklist
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
