### PR TITLE
Editorconfig special case

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -1135,7 +1135,6 @@ fi
 ########################
 # EDITORCONFIG LINTING #
 ########################
-echo ed: "$VALIDATE_EDITORCONFIG"
 if [ "$VALIDATE_EDITORCONFIG" == "true" ]; then
   ####################################
   # Lint the files with editorconfig #

--- a/lib/validation.sh
+++ b/lib/validation.sh
@@ -75,6 +75,12 @@ function GetValidationInfo() {
   VALIDATE_EDITORCONFIG=$(echo "$VALIDATE_EDITORCONFIG" | awk '{print tolower($0)}')
   VALIDATE_HTML=$(echo "$VALIDATE_HTML" | awk '{print tolower($0)}')
 
+  #############################
+  # Editorconfig special case #
+  #############################
+  LINTER_RULES_PATH="${LINTER_RULES_PATH:-.github/linters}"               # Linter Path Directory
+  EDITORCONFIG_FILE_NAME='.editorconfig'
+
   ################################################
   # Determine if any linters were explicitly set #
   ################################################
@@ -484,10 +490,13 @@ function GetValidationInfo() {
       VALIDATE_EDITORCONFIG="false"
     fi
   else
-    # No linter flags were set - default all to true
-    VALIDATE_EDITORCONFIG="true"
+    # No linter flags were set
+    # special case cehcking for .editorconfig
+    if [ -f "$GITHUB_WORKSPACE/$LINTER_RULES_PATH/$EDITORCONFIG_FILE_NAME" ]; then
+      VALIDATE_EDITORCONFIG="true"
+    fi
   fi
-  
+
   ####################################
   # Validate if we should check HTML #
   ####################################

--- a/lib/validation.sh
+++ b/lib/validation.sh
@@ -75,12 +75,6 @@ function GetValidationInfo() {
   VALIDATE_EDITORCONFIG=$(echo "$VALIDATE_EDITORCONFIG" | awk '{print tolower($0)}')
   VALIDATE_HTML=$(echo "$VALIDATE_HTML" | awk '{print tolower($0)}')
 
-  #############################
-  # Editorconfig special case #
-  #############################
-  LINTER_RULES_PATH="${LINTER_RULES_PATH:-.github/linters}"               # Linter Path Directory
-  EDITORCONFIG_FILE_NAME='.editorconfig'
-
   ################################################
   # Determine if any linters were explicitly set #
   ################################################
@@ -491,8 +485,8 @@ function GetValidationInfo() {
     fi
   else
     # No linter flags were set
-    # special case cehcking for .editorconfig
-    if [ -f "$GITHUB_WORKSPACE/$LINTER_RULES_PATH/$EDITORCONFIG_FILE_NAME" ]; then
+    # special case checking for .editorconfig
+    if [ -f "$GITHUB_WORKSPACE/.editorconfig" ]; then
       VALIDATE_EDITORCONFIG="true"
     fi
   fi


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Following the logic from [here](https://github.com/github/super-linter/pull/221/files#diff-c7b422f2f140a91b67618e5aa86d8d88R477) if we don't specify any linter flag (i.e use all linters) then, editorconfig will run against the entire code base, even if there is no `.editorconfig` present, and it will even check the `.git/` folder.

<!-- Describe what the changes are -->
## Proposed Changes
In some sense this is expected because we are not specifying any linter, so all should be run. But as this one is special and lints the entire code base, I think is worth putting an extra check to only do it if either the flag is set, or `.editorconfig` is present as a special case because this behavior is different from other linters (run only against files from that extension/type).

I'm open to all feedback here. specially @mstruebing 

PD: I think another needed change (independent of this one) is to exclude `.git/` from editor config.

PD2: Not sure if this is a typo or what is the purpose of [this](https://github.com/github/super-linter/pull/221/files#diff-2b006ea0cfcfac29e33a1b9eef9974c1R1138)?
<!-- markdownlint-restore -->

## Readiness Checklist
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
