### PR TITLE
Fix dockerfilelint -c option usage

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -54,8 +54,7 @@ TYPESCRIPT_STANDARD_LINTER_RULES=''                                     # ENV st
 ANSIBLE_FILE_NAME='.ansible-lint.yml'                                   # Name of the file
 ANSIBLE_LINTER_RULES="$DEFAULT_RULES_LOCATION/$ANSIBLE_FILE_NAME"       # Path to the Ansible lint rules
 # Docker Vars
-DOCKER_FILE_NAME='.dockerfilelintrc'                                    # Name of the file
-DOCKER_LINTER_RULES="$DEFAULT_RULES_LOCATION/$DOCKER_FILE_NAME"         # Path to the Docker lint rules
+DOCKER_LINTER_RULES="$DEFAULT_RULES_LOCATION"                           # Path to the Docker lint rules
 # Golang Vars
 GO_FILE_NAME='.golangci.yml'                                            # Name of the file
 GO_LINTER_RULES="$DEFAULT_RULES_LOCATION/$GO_FILE_NAME"                 # Path to the Go lint rules
@@ -1177,7 +1176,7 @@ if [ "$VALIDATE_DOCKER" == "true" ]; then
   #########################
   # LintCodebase "FILE_TYPE" "LINTER_NAME" "LINTER_CMD" "FILE_TYPES_REGEX" "FILE_ARRAY"
   # NOTE: dockerfilelint's "-c" option expects the folder *containing* the DOCKER_LINTER_RULES file
-  LintCodebase "DOCKER" "/dockerfilelint/bin/dockerfilelint" "/dockerfilelint/bin/dockerfilelint -c $(dirname $DOCKER_LINTER_RULES)" ".*\(Dockerfile\)\$" "${FILE_ARRAY_DOCKER[@]}"
+  LintCodebase "DOCKER" "/dockerfilelint/bin/dockerfilelint" "/dockerfilelint/bin/dockerfilelint -c $DOCKER_LINTER_RULES" ".*\(Dockerfile\)\$" "${FILE_ARRAY_DOCKER[@]}"
 fi
 
 ###################

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -1176,7 +1176,8 @@ if [ "$VALIDATE_DOCKER" == "true" ]; then
   # Lint the docker files #
   #########################
   # LintCodebase "FILE_TYPE" "LINTER_NAME" "LINTER_CMD" "FILE_TYPES_REGEX" "FILE_ARRAY"
-  LintCodebase "DOCKER" "/dockerfilelint/bin/dockerfilelint" "/dockerfilelint/bin/dockerfilelint -c $DOCKER_LINTER_RULES" ".*\(Dockerfile\)\$" "${FILE_ARRAY_DOCKER[@]}"
+  # NOTE: dockerfilelint's "-c" option expects the folder *containing* the DOCKER_LINTER_RULES file
+  LintCodebase "DOCKER" "/dockerfilelint/bin/dockerfilelint" "/dockerfilelint/bin/dockerfilelint -c $(dirname $DOCKER_LINTER_RULES)" ".*\(Dockerfile\)\$" "${FILE_ARRAY_DOCKER[@]}"
 fi
 
 ###################


### PR DESCRIPTION
dockerfilelint's "-c" option expects a path to the folder *containing* the DOCKER_LINTER_RULES file

Based on @LukeMondy 's suggestion: https://github.com/github/super-linter/issues/305#issuecomment-651571788

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->
Should fix #355
<!-- markdownlint-restore -->

<!-- Describe what the changes are -->
## Proposed Changes

- Pass the path to the folder _containing_ the `DOCKER_LINTER_RULES` file, instead of the `DOCKER_LINTER_RULES` itself
   See: https://github.com/replicatedhq/dockerfilelint/pull/138
   > This option needs to be used with the path for the file not directly to the file. This is because https://github.com/replicatedhq/dockerfilelint/blob/master/lib/index.js#L85 adds the `.dockerfilelintrc` automatically.

## Readiness Checklist
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
