### PR TITLE
Revert "seems to be the simplier path" - Fix dockerfilelint -c option usage

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -54,7 +54,8 @@ TYPESCRIPT_STANDARD_LINTER_RULES=''                                     # ENV st
 ANSIBLE_FILE_NAME='.ansible-lint.yml'                                   # Name of the file
 ANSIBLE_LINTER_RULES="$DEFAULT_RULES_LOCATION/$ANSIBLE_FILE_NAME"       # Path to the Ansible lint rules
 # Docker Vars
-DOCKER_LINTER_RULES="$DEFAULT_RULES_LOCATION"                           # Path to the Docker lint rules
+DOCKER_FILE_NAME='.dockerfilelintrc'                                    # Name of the file
+DOCKER_LINTER_RULES="$DEFAULT_RULES_LOCATION/$DOCKER_FILE_NAME"         # Path to the Docker lint rules
 # Golang Vars
 GO_FILE_NAME='.golangci.yml'                                            # Name of the file
 GO_LINTER_RULES="$DEFAULT_RULES_LOCATION/$GO_FILE_NAME"                 # Path to the Go lint rules
@@ -1204,7 +1205,7 @@ if [ "$VALIDATE_DOCKER" == "true" ]; then
   #########################
   # LintCodebase "FILE_TYPE" "LINTER_NAME" "LINTER_CMD" "FILE_TYPES_REGEX" "FILE_ARRAY"
   # NOTE: dockerfilelint's "-c" option expects the folder *containing* the DOCKER_LINTER_RULES file
-  LintCodebase "DOCKER" "/dockerfilelint/bin/dockerfilelint" "/dockerfilelint/bin/dockerfilelint -c $DOCKER_LINTER_RULES" ".*\(Dockerfile\)\$" "${FILE_ARRAY_DOCKER[@]}"
+  LintCodebase "DOCKER" "/dockerfilelint/bin/dockerfilelint" "/dockerfilelint/bin/dockerfilelint -c $(dirname $DOCKER_LINTER_RULES)" ".*\(Dockerfile\)\$" "${FILE_ARRAY_DOCKER[@]}"
 fi
 
 ###################


### PR DESCRIPTION
@admiralAwkbar:

Unfortunately commit 1da8c13a40b832bbbfd270566b54489bd2cadee8 does not work for similar reasons to those listed in @LukeMondy's comment: https://github.com/github/super-linter/issues/305#issuecomment-651571788 (I have tested with and without this commit.)

(The `GetLinterRules` function sets `LANGUAGE_LINTER_RULES` to a path including the filename again.)

I suppose we could also modify how `GetLinterRules` works, but reverting this commit seems like the easier solution - given all _other_ linters seem to expect a path *including* the filename - and fixes the use of the dockerfilelintrc file.

> **Note:** `dockerfilelint` silently proceeds with default settings if the path provided to the `-c` option doesn't match what it expects, so it's critical to test with (a) a dockerfile that triggers default warnings and (b) a custom dockerfilelintrc file that disables them


<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->
Fixes #355
<!-- markdownlint-restore -->

<!-- Describe what the changes are -->
## Proposed Changes

- This reverts commit 1da8c13a40b832bbbfd270566b54489bd2cadee8, which seems the simplest change to fix the dockerfilelintrc functionality (without substantial other changes to functions like `GetLinterRules` for this singular exception).

## Readiness Checklist
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
