### PR TITLE
small fix for git folder

### DIFF
--- a/lib/buildFileList.sh
+++ b/lib/buildFileList.sh
@@ -26,7 +26,7 @@ function BuildFileList() {
   # Switch codebase back to the default branch to get a list of all files changed #
   #################################################################################
   SWITCH_CMD=$(
-    git -C "$GITHUB_WORKSPACE" pull --quiet
+    # git -C "$GITHUB_WORKSPACE" pull --quiet
     git -C "$GITHUB_WORKSPACE" checkout "$DEFAULT_BRANCH" 2>&1
   )
 

--- a/lib/worker.sh
+++ b/lib/worker.sh
@@ -142,6 +142,9 @@ function LintCodebase() {
       elif [[ $FILE == *"$TEST_CASE_FOLDER"* ]]; then
         # This is the test cases, we should always skip
         continue
+      elif [[ $FILE == *".git"* ]]; then
+        # This is likely the .git folder and shouldnt be parsed
+        continue
       fi
 
       ##############


### PR DESCRIPTION
This closes #395 

This will help the linter skip the `.git/` folder as it should never really be parsed...