### PR TITLE
Correct stale bot exempt label syntax

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -37,9 +37,9 @@ jobs:
           days-before-stale: 30
           days-before-close: 14
           stale-issue-label: "O: stale 🤖"
-          exempt-issue-label: "O: backlog 🤖"
+          exempt-issue-labels: "O: backlog 🤖"
           stale-pr-label: "O: stale 🤖"
-          exempt-pr-label: "O: backlog 🤖"
+          exempt-pr-labels: "O: backlog 🤖"
 
   ##################
   # Mark not stale #


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->
This should correct [these](https://github.com/github/super-linter/runs/867395200?check_suite_focus=true#step:2:1) warnings
<!-- markdownlint-restore -->

<!-- Describe what the changes are -->
## Proposed Changes
- Follow proper naming of stale bot input parameters

## Readiness Checklist
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
