### PR TITLE
Use Docker instead of run-time build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ author: 'GitHub'
 description: 'It is a simple combination of various linters, written in bash, to help validate your source code.'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://github/super-linter'
 branding:
   icon: 'check-square' 
   color: 'white'

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ author: 'GitHub'
 description: 'It is a simple combination of various linters, written in bash, to help validate your source code.'
 runs:
   using: 'docker'
-  image: 'docker://github/super-linter'
+  image: 'docker://github/super-linter:v3'
 branding:
   icon: 'check-square' 
   color: 'white'


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->
No related issue

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->
## Proposed Changes

- When a user goes to the Marketplace to add the super linter, the button shown below should guide them to use the docker image and not the dockerfile which requires a large amount of build time at each run.

<img width="331" alt="Screen Shot 2020-07-16 at 6 57 50 AM" src="https://user-images.githubusercontent.com/6935431/87681246-54e86f80-c733-11ea-81fb-07292d5b4caf.png">
low performant instructions show when you click the green button...<img width="440" alt="Screen Shot 2020-07-16 at 6 45 57 AM" src="https://user-images.githubusercontent.com/6935431/87682237-7a29ad80-c734-11ea-951b-5e850e8486ad.png">

## Readiness Checklist
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
