### PR TITLE
Ansible: fix globbing issue and allow .yaml too

### DIFF
--- a/lib/worker.sh
+++ b/lib/worker.sh
@@ -604,7 +604,7 @@ function LintAnsibleFiles() {
     #################################
     # Get list of all files to lint #
     #################################
-    mapfile -t LIST_FILES < <(ls "$ANSIBLE_DIRECTORY/*.yml" 2>&1)
+    mapfile -t LIST_FILES < <(ls "$ANSIBLE_DIRECTORY"/*.{yaml,yml} 2>&1)
 
     ###############################################################
     # Set the list to empty if only MD and TXT files were changed #


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->
Relates to #272 
<!-- markdownlint-restore -->

<!-- Describe what the changes are -->
## Proposed Changes

1. Allow .yml and .yaml files to be linted
1. Globbing is not possible within quotes (http://tldp.org/LDP/abs/html/globbingref.html)

> Bash performs filename expansion on unquoted command-line arguments.

## Readiness Checklist
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
