### PR TITLE
Fix wrong config on dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,8 +21,7 @@ updates:
     directory: "/dependencies"
     schedule:
       interval: "daily"
-    labels:
-      - "Type: Maintenance"
+    open-pull-requests-limit: 10
 
   # Maintain dependencies for docker
   - package-ecosystem: "docker"
@@ -37,3 +36,4 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->
Fixes minor config error on dependabot
<!-- markdownlint-restore -->


## Readiness Checklist
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
