### PR TITLE
Simplify extension extraction

### DIFF
--- a/lib/buildFileList.sh
+++ b/lib/buildFileList.sh
@@ -84,9 +84,10 @@ function BuildFileList() {
     ###########################
     # Get the files extension #
     ###########################
-    # Extract just the file and extension, reverse it, cut off extension,
-    # reverse it back, substitute to lowercase
-    FILE_TYPE=$(basename "${FILE}" | rev | cut -f1 -d'.' | rev | awk '{print tolower($0)}')
+    # Extract just the file extension
+    FILE_TYPE=${FILE##*.}
+    # To lowercase
+    FILE_TYPE=${FILE_TYPE,,}
 
     ##############
     # Print file #


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes https://github.com/github/super-linter/pull/457 (not a fix, just a follow up)

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Use bash shell expansion to simplify the logic to extract the file extension and convert it to lowercase

No need to put my thing down flip it and reverse it.
![image](https://user-images.githubusercontent.com/725456/88208685-3b559500-cc17-11ea-9a8f-9b2303af6892.png)

## Readiness Checklist

- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
