### PR TITLE
Dart fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -174,7 +174,7 @@ RUN curl -sSLO https://github.com/pinterest/ktlint/releases/latest/download/ktli
 ####################
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
 RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk
-RUN apk add --no-cache glibc-${GLIBC_VERSION}.apk
+RUN apk add --no-cache glibc-${GLIBC_VERSION}.apk && rm glibc-${GLIBC_VERSION}.apk
 RUN wget https://storage.googleapis.com/dart-archive/channels/stable/release/${DART_VERSION}/sdk/dartsdk-linux-x64-release.zip -O - -q | unzip -q - \
     && chmod +x dart-sdk/bin/dart* \
     && mv dart-sdk/bin/* /usr/bin/ && mv dart-sdk/lib/* /usr/lib/ && mv dart-sdk/include/* /usr/include/ \

--- a/TEMPLATES/analysis_options.yaml
+++ b/TEMPLATES/analysis_options.yaml
@@ -1,0 +1,57 @@
+---
+##########################
+##########################
+## Dart Linter rules    ##
+##########################
+##########################
+
+# Pedantic Rules
+# https://github.com/dart-lang/pedantic
+
+linter:
+  rules:
+    - always_declare_return_types
+    - always_require_non_null_named_parameters
+    - annotate_overrides
+    - avoid_empty_else
+    - avoid_init_to_null
+    - avoid_null_checks_in_equality_operators
+    - avoid_relative_lib_imports
+    - avoid_return_types_on_setters
+    - avoid_shadowing_type_parameters
+    - avoid_types_as_parameter_names
+    - camel_case_extensions
+    - curly_braces_in_flow_control_structures
+    - empty_catches
+    - empty_constructor_bodies
+    - library_names
+    - library_prefixes
+    - no_duplicate_case_values
+    - null_closures
+    - omit_local_variable_types
+    - prefer_adjacent_string_concatenation
+    - prefer_collection_literals
+    - prefer_conditional_assignment
+    - prefer_contains
+    - prefer_equal_for_default_values
+    - prefer_final_fields
+    - prefer_for_elements_to_map_fromIterable
+    - prefer_generic_function_type_aliases
+    - prefer_if_null_operators
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_iterable_whereType
+    - prefer_single_quotes
+    - prefer_spread_collections
+    - recursive_getters
+    - slash_for_doc_comments
+    - type_init_formals
+    - unawaited_futures
+    - unnecessary_const
+    - unnecessary_new
+    - unnecessary_null_in_if_null_operators
+    - unnecessary_this
+    - unrelated_type_equality_checks
+    - use_function_type_syntax_for_parameters
+    - use_rethrow_when_possible
+    - valid_regexps

--- a/docs/disabling-linters.md
+++ b/docs/disabling-linters.md
@@ -35,6 +35,7 @@ For some linters it is also possible to override rules on a case by case level w
 - [Dockerfile](#dockerfile)
 - [Terraform](#terraform)
 - [CSS](#css)
+- [DART](#dart)
 - [ENV](#dotenv-linter)
 - [Kotlin](#kotlin)
 - [OpenAPI](#openapi)
@@ -826,7 +827,7 @@ import package.b.*
 
 - `.github/linters/.dart-lint.yml`
 - You can pass multiple rules and overwrite default rules
-- File should be located at: `.github/linters/.dart-lint.yml`
+- File should be located at: `.github/linters/anaylsis_options.yaml`
 
 ### dartanalyzer disable single line
 
@@ -844,7 +845,7 @@ int x = ''; // ignore: invalid_assignment
 
 ### dartanalyzer disable entire file
 
-- You can disable entire files with the `analyzer.exclude` property in `.dart-lint.yml`
+- You can disable entire files with the `analyzer.exclude` property in `anaylsis_options.yaml`
 
 ```dart
 analyzer:

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -1388,7 +1388,7 @@ if [ "${VALIDATE_DART}" == "true" ]; then
   # Lint the Dart files #
   #######################
   # LintCodebase "FILE_TYPE" "LINTER_NAME" "LINTER_CMD" "FILE_TYPES_REGEX" "FILE_ARRAY"
-  LintCodebase "DART" "dart" "pub get || true && dartanalyzer --fatal-infos --fatal-warnings --options ${DART_LINTER_RULES}" ".*\.\(dart\)\$" "${FILE_ARRAY_DART[@]}"
+  LintCodebase "DART" "dart" "dartanalyzer --fatal-infos --fatal-warnings --options ${DART_LINTER_RULES}" ".*\.\(dart\)\$" "${FILE_ARRAY_DART[@]}"
 fi
 
 ##################


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes issues with dart pointed out in #120 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

This change backs out the `pub get || true` in `linter.sh` for the following reasons:

- `pub get` should only run once
  - `pub-get` should run before super-linter in it's own stage
- I'm not seeing this approach with other linters in super-linter and prefer a standardized approach
- Tests were not using `pub get` so they're were not testing the functionality/use case.

## Proposed Changes

1. Calling `pub get` on each lint even with `|| true` is undesirable coupled with the fact it does not retain `+x` on copy when building `Dockerfile` (some how everything else in dart-sdk does?, not a super-linter issue). 
2. I left the glibc apk package laying around, cleaning up
3. Update wiki to reflect the `analysis_options.yaml` file
4. Doh, left the template out some how

## Readiness Checklist

- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
