### PR TITLE
fix disabling-linters documentation

### DIFF
--- a/docs/disabling-linters.md
+++ b/docs/disabling-linters.md
@@ -954,8 +954,6 @@ lint:
 ## EDITORCONFIG-CHECKER
 - [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker)
 
----
-
 ### editorconfig-checker Config file
 - `.github/linters/.ecrc`
 - This linter will also use the [`.editorconfig`](https://editorconfig.org/) of your project

--- a/docs/disabling-linters.md
+++ b/docs/disabling-linters.md
@@ -954,7 +954,7 @@ lint:
 ## EDITORCONFIG-CHECKER
 - [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker)
 
---------------------------------------------------------------------------------
+---
 
 ### editorconfig-checker Config file
 - `.github/linters/.ecrc`

--- a/docs/disabling-linters.md
+++ b/docs/disabling-linters.md
@@ -39,6 +39,7 @@ For some linters it is also possible to override rules on a case by case level w
 - [Kotlin](#kotlin)
 - [OpenAPI](#openapi)
 - [Protocol Buffers](#protocol-buffers)
+- [Clojure](#clojure)
 - [EDITORCONFIG-CHECKER](#editorconfig-checker)
 - [HTML](#html)
 
@@ -946,8 +947,9 @@ lint:
 
 ### clj-kondo disable entire file
 
-````clojure
+```clojure
 {:output {:exclude-files ["path/to/file"]}}
+```
 
 ## EDITORCONFIG-CHECKER
 - [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker)
@@ -1003,4 +1005,3 @@ lint:
 ### htmlhint disable entire file
 
 - There is currently **No** way to disable rules in an entire file
-````


### PR DESCRIPTION
On Disabling linters and Rules documentation I fixed two minor issues:
* Fix link to Clojure
* Everything after Clojure chapter was not properly defined (anymore)
* Remove surplus horizontal line
