### PR TITLE
Adding LFS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,23 +54,19 @@ RUN apk add --update --no-cache \
     bash \
     curl \
     gcc \
-    git \
+    git git-lfs\
     go \
     icu-libs \
     jq \
     libxml2-utils \
     make \
     musl-dev \
-    npm \
-    nodejs \
+    npm nodejs \
     openjdk8-jre \
     perl \
     php7 \
     py3-setuptools \
-    ruby \
-    ruby-dev \
-    ruby-bundler \
-    ruby-rdoc
+    ruby ruby-dev ruby-bundler ruby-rdoc
 
 ########################################
 # Copy dependencies files to container #


### PR DESCRIPTION
This closes #454

We should never have to `lint` a Git LFS object, but a simple solution to remove the warning/error is to have the binaries installed in the system.

This should be a simple fix to the reported errors...