### PR TITLE
Fix YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ and won't run anything unexpected.
 | **VALIDATE_TYPESCRIPT_STANDARD** | `true`                | Flag to enable or disable the linting process of the Typescript language. (Utilizing: standard)                                                                                  |
 | **VALIDATE_XML**                 | `true`                | Flag to enable or disable the linting process of the XML language.                                                                                                               |
 | **VALIDATE_YAML**                | `true`                | Flag to enable or disable the linting process of the YAML language.                                                                                                              |
+| **YAML_CONFIG_FILE**             | `.yaml-lint.yml`      | Filename for [Yamllint configuration](https://yamllint.readthedocs.io/en/stable/configuration.html) (ex: `.yaml-lint.yml`, `.yamllint.yml`)                                      |
+
 
 ### Template rules files
 

--- a/lib/buildFileList.sh
+++ b/lib/buildFileList.sh
@@ -106,7 +106,7 @@ function BuildFileList() {
       ################################
       # Append the file to the array #
       ################################
-      FILE_ARRAY_YML+=("${FILE}")
+      FILE_ARRAY_YAML+=("${FILE}")
       ##########################################################
       # Set the READ_ONLY_CHANGE_FLAG since this could be exec #
       ##########################################################

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -88,7 +88,7 @@ TYPESCRIPT_FILE_NAME="${TYPESCRIPT_ES_CONFIG_FILE:-.eslintrc.yml}"              
 TYPESCRIPT_LINTER_RULES="${DEFAULT_RULES_LOCATION}/${TYPESCRIPT_FILE_NAME}"           # Path to the Typescript lint rules
 TYPESCRIPT_STANDARD_LINTER_RULES=''                                                   # ENV string to pass when running js standard
 # YAML Vars
-YAML_FILE_NAME='.yaml-lint.yml'                                                       # Name of the file
+YAML_FILE_NAME="${YAML_CONFIG_FILE:-.yaml-lint.yml}"                                  # Name of the file
 YAML_LINTER_RULES="${DEFAULT_RULES_LOCATION}/${YAML_FILE_NAME}"                       # Path to the yaml lint rules
 
 #######################################

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -109,7 +109,7 @@ LANGUAGE_ARRAY=('ANSIBLE' 'ARM' 'BASH' 'CLOUDFORMATION' 'CLOJURE' 'COFFEESCRIPT'
   'JAVASCRIPT_STANDARD' 'JSON' 'JSX' 'KOTLIN' 'MARKDOWN' 'OPENAPI'
   'PERL' 'PHP' 'POWERSHELL' 'PROTOBUF' 'PYTHON'
   'RAKU' 'RUBY' 'STATES' 'TERRAFORM' 'TERRAFORM_TERRASCAN' 'TSX' 'TYPESCRIPT_ES'
-  'TYPESCRIPT_STANDARD' 'XML' 'YML')
+  'TYPESCRIPT_STANDARD' 'XML' 'YAML')
 
 ############################################
 # Array for all languages that were linted #
@@ -242,7 +242,7 @@ FILE_ARRAY_TSX=()                 # Array of files to check
 FILE_ARRAY_TYPESCRIPT_ES=()       # Array of files to check
 FILE_ARRAY_TYPESCRIPT_STANDARD=() # Array of files to check
 FILE_ARRAY_XML=()                 # Array of files to check
-FILE_ARRAY_YML=()                 # Array of files to check
+FILE_ARRAY_YAML=()                # Array of files to check
 
 ############
 # Counters #
@@ -315,8 +315,8 @@ ERRORS_FOUND_TYPESCRIPT_ES=0            # Count of errors found
 export ERRORS_FOUND_TYPESCRIPT_ES       # Workaround SC2034
 ERRORS_FOUND_XML=0                      # Count of errors found
 export ERRORS_FOUND_XML                 # Workaround SC2034
-ERRORS_FOUND_YML=0                      # Count of errors found
-export ERRORS_FOUND_YML                 # Workaround SC2034
+ERRORS_FOUND_YAML=0                     # Count of errors found
+export ERRORS_FOUND_YAML                # Workaround SC2034
 
 ################################################################################
 ########################## FUNCTIONS BELOW #####################################
@@ -1092,7 +1092,7 @@ GetLinterRules "RUBY"
 GetLinterRules "TERRAFORM"
 # Get TypeScript rules
 GetLinterRules "TYPESCRIPT"
-# Get YML rules
+# Get YAML rules
 GetLinterRules "YAML"
 
 #################################
@@ -1623,14 +1623,14 @@ if [ "${VALIDATE_XML}" == "true" ]; then
 fi
 
 ###############
-# YML LINTING #
+# YAML LINTING #
 ###############
 if [ "${VALIDATE_YAML}" == "true" ]; then
   ######################
   # Lint the Yml Files #
   ######################
   # LintCodebase "FILE_TYPE" "LINTER_NAME" "LINTER_CMD" "FILE_TYPES_REGEX" "FILE_ARRAY"
-  LintCodebase "YML" "yamllint" "yamllint -c ${YAML_LINTER_RULES}" ".*\.\(yml\|yaml\)\$" "${FILE_ARRAY_YML[@]}"
+  LintCodebase "YAML" "yamllint" "yamllint -c ${YAML_LINTER_RULES}" ".*\.\(yml\|yaml\)\$" "${FILE_ARRAY_YAML[@]}"
 fi
 
 ###########

--- a/lib/worker.sh
+++ b/lib/worker.sh
@@ -610,7 +610,7 @@ function RunTestCases() {
   TestCodebase "TYPESCRIPT_ES" "eslint" "eslint --no-eslintrc -c ${TYPESCRIPT_LINTER_RULES}" ".*\.\(ts\)\$" "typescript"
   TestCodebase "TYPESCRIPT_STANDARD" "standard" "standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin ${TYPESCRIPT_STANDARD_LINTER_RULES}" ".*\.\(ts\)\$" "typescript"
   TestCodebase "XML" "xmllint" "xmllint" ".*\.\(xml\)\$" "xml"
-  TestCodebase "YML" "yamllint" "yamllint -c ${YAML_LINTER_RULES}" ".*\.\(yml\|yaml\)\$" "yml"
+  TestCodebase "YAML" "yamllint" "yamllint -c ${YAML_LINTER_RULES}" ".*\.\(yml\|yaml\)\$" "yml"
 
   #################
   # Footer prints #


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes a bug when linting all code base, YAML is being skipped because when we build the var, we use `"VALIDATE_${LANGUAGE}"` and it was defined as YML, so it was creating `VALIDATE_YML` instead of `VALIDATE_YAML`

I replaced everywhere for consistency and avoid other errors

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. User YAML for variable names everywhere
2. I also added the var to allow to set the yaml config file, as here we also use non standard file name.

## Readiness Checklist

- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
