### PR TITLE
Fix log sources in docker scripts

### DIFF
--- a/.automation/cleanup-docker.sh
+++ b/.automation/cleanup-docker.sh
@@ -17,7 +17,7 @@
 # Source Function Files #
 #########################
 # shellcheck source=/dev/null
-source /action/lib/log.sh # Source the function script(s)
+source ../lib/log.sh # Source the function script(s)
 
 ###########
 # Globals #

--- a/.automation/upload-docker.sh
+++ b/.automation/upload-docker.sh
@@ -18,7 +18,7 @@
 # Source Function Files #
 #########################
 # shellcheck source=/dev/null
-source /action/lib/log.sh # Source the function script(s)
+source ../lib/log.sh # Source the function script(s)
 
 ###########
 # Globals #


### PR DESCRIPTION
Follow up from https://github.com/github/super-linter/pull/486
which caused https://github.com/github/super-linter/actions/runs/189243004 due to not being able to find the log functions.