### PR TITLE
Fix a few typos in the Dart docs

### DIFF
--- a/docs/disabling-linters.md
+++ b/docs/disabling-linters.md
@@ -243,7 +243,7 @@ a {
 
 - `.github/linters/.dart-lint.yml`
 - You can pass multiple rules and overwrite default rules
-- File should be located at: `.github/linters/anaylsis_options.yaml`
+- File should be located at: `.github/linters/analysis_options.yaml`
 
 ### dartanalyzer disable single line
 
@@ -261,7 +261,7 @@ int x = ''; // ignore: invalid_assignment
 
 ### dartanalyzer disable entire file
 
-- You can disable entire files with the `analyzer.exclude` property in `anaylsis_options.yaml`
+- You can disable entire files with the `analyzer.exclude` property in `analysis_options.yaml`
 
 ```dart
 analyzer:


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes the path to `.github/linters/analysis_options.yaml`, which was misspelled in two places.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Fix the path to `.github/linters/analysis_options.yaml`, which was misspelled in two places.

## Readiness Checklist

- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
