### PR TITLE
Fix log function locations in automation

### DIFF
--- a/.automation/cleanup-docker.sh
+++ b/.automation/cleanup-docker.sh
@@ -13,12 +13,6 @@
 # - System with Docker installed
 # - Global variables met
 
-#########################
-# Source Function Files #
-#########################
-# shellcheck source=/dev/null
-source ../lib/log.sh # Source the function script(s)
-
 ###########
 # Globals #
 ###########
@@ -28,6 +22,12 @@ DOCKER_PASSWORD="${DOCKER_PASSWORD}"   # Password to login to DockerHub
 IMAGE_REPO="${IMAGE_REPO}"             # Image repo to upload the image
 IMAGE_VERSION="${IMAGE_VERSION}"       # Version to tag the image
 DOCKERFILE_PATH="${DOCKERFILE_PATH}"   # Path to the Dockerfile to be uploaded
+
+#########################
+# Source Function Files #
+#########################
+# shellcheck source=/dev/null
+source "${GITHUB_WORKSPACE}/lib/log.sh" # Source the function script(s)
 
 ################################################################################
 ############################ FUNCTIONS BELOW ###################################

--- a/.automation/upload-docker.sh
+++ b/.automation/upload-docker.sh
@@ -14,12 +14,6 @@
 # - System with Docker installed
 # - Global variables met
 
-#########################
-# Source Function Files #
-#########################
-# shellcheck source=/dev/null
-source ../lib/log.sh # Source the function script(s)
-
 ###########
 # Globals #
 ###########
@@ -34,6 +28,12 @@ IMAGE_VERSION="${IMAGE_VERSION}"       # Version to tag the image
 DOCKERFILE_PATH="${DOCKERFILE_PATH}"   # Path to the Dockerfile to be uploaded
 MAJOR_TAG=''                           # Major tag version if we need to update it
 UPDATE_MAJOR_TAG=0                     # Flag to deploy the major tag version as well
+
+#########################
+# Source Function Files #
+#########################
+# shellcheck source=/dev/null
+source "${GITHUB_WORKSPACE}/lib/log.sh" # Source the function script(s)
 
 ################################################################################
 ############################ FUNCTIONS BELOW ###################################


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes https://github.com/github/super-linter/runs/946764117?check_suite_focus=true#step:3:11

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Move log functions below global vars
2. Source log functions using `${GITHUB_WORKSPACE}` instead of relative paths

## Readiness Checklist

- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
