### PR TITLE
Separate maintainer and contributor jobs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 ######################################################################
 # These owners will be the default owners for everything in the repo #
 ######################################################################
-*       @admiralawkbar @jwiebalk @zkoppert @IAmHughes @nemchik @Hanse00 @dependabot[bot]
+*       @admiralawkbar @jwiebalk @zkoppert @IAmHughes @nemchik @Hanse00 @dependabot

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,4 @@
 ######################################################################
 # These owners will be the default owners for everything in the repo #
 ######################################################################
-*       @admiralawkbar @jwiebalk @zkoppert @IAmHughes @nemchik @Hanse00
-
-####################################################
-# Adding dependabot for auto merge on dependancies #
-####################################################
-*       @dependabot[bot]
+*       @admiralawkbar @jwiebalk @zkoppert @IAmHughes @nemchik @Hanse00 @dependabot[bot]

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 ######################################################################
 # These owners will be the default owners for everything in the repo #
 ######################################################################
-*       @admiralawkbar @jwiebalk @zkoppert @IAmHughes @nemchik @Hanse00 @dependabot
+*       @admiralawkbar @jwiebalk @zkoppert @IAmHughes @nemchik @Hanse00 @dependabot-bot

--- a/.github/pull_request-template.md
+++ b/.github/pull_request-template.md
@@ -16,5 +16,9 @@ Fixes #
 
 ## Readiness Checklist
 
+### Author/Contributor
+- [ ] If documentation is needed for this change, has that been included in this pull request
+
+### Reviewing Maintainer 
 - [ ] Label as `breaking` if this is a large fundamental change
 - [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

This will avoid confusion on who should add labels

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Maintainers reviewing should add label before merge
2. Documentation should be included for changesets that need it

## Readiness Checklist

- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
