### PR TITLE
Adds --external-sources option for shellcheck

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -1289,7 +1289,7 @@ if [ "${VALIDATE_BASH}" == "true" ]; then
   # Lint the bash files #
   #######################
   # LintCodebase "FILE_TYPE" "LINTER_NAME" "LINTER_CMD" "FILE_TYPES_REGEX" "FILE_ARRAY"
-  LintCodebase "BASH" "shellcheck" "shellcheck --color" ".*\.\(sh\|bash\|dash\|ksh\)\$" "${FILE_ARRAY_BASH[@]}"
+  LintCodebase "BASH" "shellcheck" "shellcheck --color --external-sources" ".*\.\(sh\|bash\|dash\|ksh\)\$" "${FILE_ARRAY_BASH[@]}"
 fi
 
 ##########################

--- a/lib/worker.sh
+++ b/lib/worker.sh
@@ -570,7 +570,7 @@ function RunTestCases() {
   # TestCodebase "Language" "Linter" "Linter-command" "Regex to find files" "Test Folder"
   TestCodebase "ANSIBLE" "ansible-lint" "ansible-lint -v -c ${ANSIBLE_LINTER_RULES}" ".*\.\(yml\|yaml\)\$" "ansible"
   TestCodebase "ARM" "arm-ttk" "Import-Module ${ARM_TTK_PSD1} ; \${config} = \$(Import-PowerShellDataFile -Path ${ARM_LINTER_RULES}) ; Test-AzTemplate @config -TemplatePath" ".*\.\(json\)\$" "arm"
-  TestCodebase "BASH" "shellcheck" "shellcheck --color" ".*\.\(sh\|bash\|dash\|ksh\)\$" "shell"
+  TestCodebase "BASH" "shellcheck" "shellcheck --color --external-sources" ".*\.\(sh\|bash\|dash\|ksh\)\$" "shell"
   TestCodebase "CLOUDFORMATION" "cfn-lint" "cfn-lint --config-file ${CLOUDFORMATION_LINTER_RULES}" ".*\.\(json\|yml\|yaml\)\$" "cloudformation"
   TestCodebase "CLOJURE" "clj-kondo" "clj-kondo --config ${CLOJURE_LINTER_RULES} --lint" ".*\.\(clj\|cljs\|cljc\|edn\)\$" "clojure"
   TestCodebase "COFFEESCRIPT" "coffeelint" "coffeelint -f ${COFFEESCRIPT_LINTER_RULES}" ".*\.\(coffee\)\$" "coffeescript"


### PR DESCRIPTION
## Proposed Changes

Include the `--external-sources` flag when invoking `shellcheck`.

Shellcheck supports a `--external-sources` option that allows directives like the follow to pass linting.

  ```
  # shellcheck source=SCRIPTDIR/some/source/script.sh`
  source "$(dirname "${BASH_SOURCE[0]}")/some/source/script.sh"
  ```
Without this option, we will see lots of spurious errors from shellcheck like the following.

  ```
  # shellcheck source=SCRIPTDIR/some/source/script.sh`
  source "$(dirname "${BASH_SOURCE[0]}")/some/source/script.sh"
         ^-- SC1091: Not following: SCRIPTDIR/some/source/script.sh: openBinaryFile: does not exist (No such file or directory)
  ```

It looks like it [may be possible](https://github.com/koalaman/shellcheck/issues/1818) to include this option in a future version of `shellcheck` through the `.shellcheckrc` configuration file, given that this issue is resolved, and that super-linter supports `.shellcheckrc` as a configuration file for `shellcheck`.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer 
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
