### PR TITLE
super slick

### DIFF
--- a/lib/buildFileList.sh
+++ b/lib/buildFileList.sh
@@ -45,12 +45,12 @@ function BuildFileList() {
   # print header #
   ################
   debug "----------------------------------------------"
-  debug "Generating Diff with:[git diff --name-only '${DEFAULT_BRANCH}..${GITHUB_SHA}' --diff-filter=d]"
+  debug "Generating Diff with:[git diff --name-only '${DEFAULT_BRANCH}...${GITHUB_SHA}' --diff-filter=d]"
 
   #################################################
   # Get the Array of files changed in the commits #
   #################################################
-  mapfile -t RAW_FILE_ARRAY < <(git -C "${GITHUB_WORKSPACE}" diff --name-only "${DEFAULT_BRANCH}..${GITHUB_SHA}" --diff-filter=d 2>&1)
+  mapfile -t RAW_FILE_ARRAY < <(git -C "${GITHUB_WORKSPACE}" diff --name-only "${DEFAULT_BRANCH}...${GITHUB_SHA}" --diff-filter=d 2>&1)
 
   #######################
   # Load the error code #


### PR DESCRIPTION
This closes #544 

- https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons

We seem to have been linting more than we wanted and the better comparison should solve the egregious overlooking...
