### PR TITLE
Better VALIDATE_[LANGUAGE] vars logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,14 @@ Using the line:`uses: docker://github/super-linter:v3` will pull the image down 
 
 The super-linter allows you to pass the following `ENV` variables to be able to trigger different functionality.
 
-_Note:_ All the `VALIDATE_[LANGUAGE]` variables behave in a specific way.
-If none of them are passed, then they all default to true.
-However if any one of the variables are set, we default to leaving any unset variable to false.
+_Note:_ All the `VALIDATE_[LANGUAGE]` variables behave in a very specific way:
+- If none of them are passed, then they all default to true.
+- If any one of the variables are set to true, we default to leaving any unset variable to false (only validate those languages).
+- If any one of the variables are set to false, we default to leaving any unset variable to true (only exclude those languages).
+- If there are `VALIDATE_[LANGUAGE]` variables set to both true and false. It will fail.
+
 This means that if you run the linter "out of the box", all languages will be checked.
-But if you wish to select specific linters, we give you full control to choose which linters are run,
-and won't run anything unexpected.
+But if you wish to select or exclude specific linters, we give you full control to choose which linters are run, and won't run anything unexpected.
 
 | **ENV VAR**                      | **Default Value**     | **Notes**                                                                                                                                                                        |
 | -------------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/lib/validation.sh
+++ b/lib/validation.sh
@@ -57,6 +57,8 @@ function GetValidationInfo() {
   # Determine if any linters were explicitly set #
   ################################################
   ANY_SET="false"
+  ANY_TRUE="false"
+  ANY_FALSE="false"
   # Loop through all languages
   for LANGUAGE in "${LANGUAGE_ARRAY[@]}"; do
     # build the variable
@@ -65,12 +67,21 @@ function GetValidationInfo() {
     if [ -n "${!VALIDATE_LANGUAGE}" ]; then
       # It was set, need to set flag
       ANY_SET="true"
+      if [ "${!VALIDATE_LANGUAGE}" == "true" ]; then
+        ANY_TRUE="true"
+      elif [ "${!VALIDATE_LANGUAGE}" == "false" ]; then
+        ANY_FALSE="true"
+      fi
     fi
   done
 
-  ###################################################
-  # Validate if we should check individual lanuages #
-  ###################################################
+  if [ $ANY_TRUE == "true" ] && [ $ANY_FALSE == "true" ]; then
+    fatal "Behavior not supported, please either only include (VALIDATE=true) or exclude (VALIDATE=false) linters, but not both"
+  fi
+
+  #########################################################
+  # Validate if we should check/omit individual languages #
+  #########################################################
   # Loop through all languages
   for LANGUAGE in "${LANGUAGE_ARRAY[@]}"; do
     # build the variable
@@ -79,8 +90,10 @@ function GetValidationInfo() {
     if [[ ${ANY_SET} == "true" ]]; then
       # Check to see if the variable was set
       if [ -z "${!VALIDATE_LANGUAGE}" ]; then
-        # Flag was not set, default to false
-        eval "${VALIDATE_LANGUAGE}='false'"
+        # Flag was not set, default to:
+        # if ANY_TRUE then set to false
+        # if ANY_FALSE then set to true
+        eval "${VALIDATE_LANGUAGE}='$ANY_FALSE'"
       fi
     else
       # No linter flags were set - default all to true

--- a/lib/worker.sh
+++ b/lib/worker.sh
@@ -78,7 +78,7 @@ function LintCodebase() {
     LIST_FILES=("${FILE_ARRAY[@]}") # Copy the array into list
   else
     ###############################################################################
-    # Set the file seperator to newline to allow for grabbing objects with spaces #
+    # Set the file separator to newline to allow for grabbing objects with spaces #
     ###############################################################################
     IFS=$'\n'
 
@@ -141,9 +141,9 @@ function LintCodebase() {
       FILE_NAME=$(basename "${FILE}" 2>&1)
       DIR_NAME=$(dirname "${FILE}" 2>&1)
 
-      #####################################################
-      # Make sure we dont lint node modules or test cases #
-      #####################################################
+      ######################################################
+      # Make sure we don't lint node modules or test cases #
+      ######################################################
       if [[ ${FILE} == *"node_modules"* ]]; then
         # This is a node modules file
         continue
@@ -151,7 +151,7 @@ function LintCodebase() {
         # This is the test cases, we should always skip
         continue
       elif [[ ${FILE} == *".git"* ]]; then
-        # This is likely the .git folder and shouldnt be parsed
+        # This is likely the .git folder and shouldn't be parsed
         continue
       fi
 
@@ -270,7 +270,7 @@ function TestCodebase() {
   LINTER_NAME="${2}"           # Pull the variable and remove from array path  (Example: jsonlint)
   LINTER_COMMAND="${3}"        # Pull the variable and remove from array path  (Example: jsonlint -c ConfigFile /path/to/file)
   FILE_EXTENSIONS="${4}"       # Pull the variable and remove from array path  (Example: *.json)
-  INDVIDUAL_TEST_FOLDER="${5}" # Folder for specific tests
+  INDIVIDUAL_TEST_FOLDER="${5}" # Folder for specific tests
   TESTS_RAN=0                  # Incremented when tests are ran, this will help find failed finds
 
   ################
@@ -312,7 +312,7 @@ function TestCodebase() {
   #################################
   # Get list of all files to lint #
   #################################
-  mapfile -t LIST_FILES < <(find "${GITHUB_WORKSPACE}/${TEST_CASE_FOLDER}/${INDVIDUAL_TEST_FOLDER}" -path "*/node_modules" -prune -o -type f -regex "${FILE_EXTENSIONS}" ! -path "${GITHUB_WORKSPACE}/${TEST_CASE_FOLDER}/ansible/ghe-initialize/*" | sort 2>&1)
+  mapfile -t LIST_FILES < <(find "${GITHUB_WORKSPACE}/${TEST_CASE_FOLDER}/${INDIVIDUAL_TEST_FOLDER}" -path "*/node_modules" -prune -o -type f -regex "${FILE_EXTENSIONS}" ! -path "${GITHUB_WORKSPACE}/${TEST_CASE_FOLDER}/ansible/ghe-initialize/*" | sort 2>&1)
 
   ########################################
   # Prepare context if TAP output format #
@@ -381,11 +381,11 @@ function TestCodebase() {
     # Check for ansible #
     #####################
     if [[ ${FILE_TYPE} == "ANSIBLE" ]]; then
-      ########################################
-      # Make sure we dont lint certain files #
-      ########################################
+      #########################################
+      # Make sure we don't lint certain files #
+      #########################################
       if [[ ${FILE} == *"vault.yml"* ]] || [[ ${FILE} == *"galaxy.yml"* ]]; then
-        # This is a file we dont look at
+        # This is a file we don't look at
         continue
       fi
 
@@ -393,7 +393,7 @@ function TestCodebase() {
       # Lint the file with the rules #
       ################################
       LINT_CMD=$(
-        cd "${GITHUB_WORKSPACE}/${TEST_CASE_FOLDER}/${INDVIDUAL_TEST_FOLDER}" || exit
+        cd "${GITHUB_WORKSPACE}/${TEST_CASE_FOLDER}/${INDIVIDUAL_TEST_FOLDER}" || exit
         ${LINTER_COMMAND} "${FILE}" 2>&1
       )
     elif [[ ${FILE_TYPE} == "POWERSHELL" ]] || [[ ${FILE_TYPE} == "ARM" ]]; then
@@ -509,7 +509,7 @@ function TestCodebase() {
     ########################################################################
     # If expected TAP report exists then compare with the generated report #
     ########################################################################
-    EXPECTED_FILE="${GITHUB_WORKSPACE}/${TEST_CASE_FOLDER}/${INDVIDUAL_TEST_FOLDER}/reports/expected-${FILE_TYPE}.tap"
+    EXPECTED_FILE="${GITHUB_WORKSPACE}/${TEST_CASE_FOLDER}/${INDIVIDUAL_TEST_FOLDER}/reports/expected-${FILE_TYPE}.tap"
     if [ -e "${EXPECTED_FILE}" ]; then
       TMPFILE=$(mktemp -q "/tmp/diff-${FILE_TYPE}.XXXXXX")
       ## Ignore white spaces, case sensitive


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->


<!-- markdownlint-restore -->

<!-- Describe what the changes are -->
Partially fixes #472, specially [this comment](https://github.com/github/super-linter/issues/472#issuecomment-663556809)

> No validate flags = all run if found
> validate flag set to true = only validate that language
> validate flag set to false - omit only that language

I tried to keep it as simple as I could, if something is not clear, or there are better ways, any feedback is much appreciated.

## Proposed Changes

1. Basically the logic described above
2. Also fixed some spelling, most of it is on another commit, so if needed can be merged on another PR

## Readiness Checklist

### Author/Contributor
- [X] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer 
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
