### PR TITLE
GROOVY: Upgrade npm-groovy-lint to v7.3.1

### DIFF
--- a/dependencies/package-lock.json
+++ b/dependencies/package-lock.json
@@ -3232,9 +3232,9 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "java-caller": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/java-caller/-/java-caller-2.0.0.tgz",
-      "integrity": "sha512-oSv2BCo1zZWo1Q6t01Bs1Gef4NXv36Rbu39n2M9vQ5Iacsopplx9ik38gfeHp4vLMuvOTVlTEnl9uAU+g3rzlA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/java-caller/-/java-caller-2.1.0.tgz",
+      "integrity": "sha512-akhcPM1YKmOWoVaNnAh0rrlyWkESa+tU9E1GxfdyotDVMe6r2w/gBJUaTmngihRbYL4QwA3NB3pu7x7sq2YH8g==",
       "requires": {
         "debug": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -3958,9 +3958,9 @@
       "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM="
     },
     "npm-groovy-lint": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-7.2.0.tgz",
-      "integrity": "sha512-USoW673L/+0/rj+kKmLPVjCtsW5Izi4T0N4ov3wjdamdeUy67/kH1VawaHiB+F3lEPjVpnkOtUDrzn3mQw5bbQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-7.3.1.tgz",
+      "integrity": "sha512-XtVeirukkDX8gBZetIpgzrmaun8UQAQarW/zFaqyM2j1HAi5eBEr6JHRwM20kbUuEpYdkczlHVIz1S7Tqex6Ew==",
       "requires": {
         "@amplitude/node": "^0.3.3",
         "ansi-colors": "^4.1.1",

--- a/dependencies/package.json
+++ b/dependencies/package.json
@@ -16,7 +16,7 @@
     "htmlhint": "^0.14.1",
     "jsonlint": "^1.6.3",
     "markdownlint-cli": "^0.23.2",
-    "npm-groovy-lint": "^7.2.0",
+    "npm-groovy-lint": "^7.3.1",
     "prettier": "^2.0.5",
     "prettyjson": "^1.2.1",
     "sql-lint": "0.0.15",


### PR DESCRIPTION
## Proposed Changes

GROOVY: Upgrade dependency npm-groovy-lint to version 7.3.1
Ascending compatibility is guaranteed so you can validate the PR without risks :)

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer 
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
