### PR TITLE
docs: remove note about using docker://

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,15 +148,12 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: docker://github/super-linter:v3
+        uses: github/super-linter@v3
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
-
-**NOTE:**
-Using the line:`uses: docker://github/super-linter:v3` will pull the image down from **DockerHub** and run the **GitHub Super-Linter**. Using the line: `uses: github/super-linter@v3` will build and compile the **GitHub Super-Linter** at build time. _This can be far more costly in time..._
 
 ## Environment variables
 


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

it seems GitHub Actions now respects `actions.yml` directives when using docker actions, thus making the note to use `docker://` redundant.

in other words: using `github/superlinter@v3` no longer results in compiling the docker image, since `action.yml` has been updated 

https://github.com/github/super-linter/blob/5c75c2fdcd47301590fdd6c0c105285b8537a0dc/action.yml#L4-L6

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

simplify docs, and use the standard gh action format of `github/super-linter@v3`

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer 
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
