### PR TITLE
adding more folders to ignore

### DIFF
--- a/lib/worker.sh
+++ b/lib/worker.sh
@@ -157,6 +157,12 @@ function LintCodebase() {
       elif [[ ${FILE} == *".git"* ]]; then
         # This is likely the .git folder and shouldn't be parsed
         continue
+      elif [[ ${FILE} == *".venv"* ]]; then
+        # This is likely the python virtual environment folder and shouldn't be parsed
+        continue
+      elif [[ ${FILE} == *".rbenv"* ]]; then
+        # This is likely the ruby environment folder and shouldn't be parsed
+        continue
       fi
 
       ##################################


### PR DESCRIPTION
This closes #614 

- We need to ignore the `.venv` from Python as they should not be linted
- We need to ignore the `.rbenv`from Ruby as they should not be linted