### PR TITLE
fix previous clean commit in lib/worker.sh

### DIFF
--- a/lib/worker.sh
+++ b/lib/worker.sh
@@ -168,6 +168,7 @@ function LintCodebase() {
           # ZSH file and we need to skip
           warn "$LINTER_NAME does NOT currently support zsh, skipping file"
           continue
+        fi
       fi
 
       ##################################


### PR DESCRIPTION
<!-- markdownlint-disable -->

Fixes bug

98c2eec42a45e7b01210b9e2bc3cf3dd724a69cc introduce a trouble :
```
/action/lib/worker.sh: line 300: syntax error near unexpected token `done'
/action/lib/worker.sh: line 300: `    done'
```

shellcheck warn us about it :
```
    ^-- SC1047: Expected 'fi' matching previously mentioned 'if'.
    ^-- SC1072: Expected 'fi'. Fix any mentioned problems and try again.
```

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer 
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
