### PR TITLE
Upgrade npm-groovy-lint dependency to 7.5.1

### DIFF
--- a/dependencies/package-lock.json
+++ b/dependencies/package-lock.json
@@ -3,20 +3,6 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
-    "@amplitude/node": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@amplitude/node/-/node-0.3.3.tgz",
-      "integrity": "sha512-Uzg4MRAuD053Ex67Iu2lm2GovnVte1uKI3q7CXlMCYZ9ylZmAkPbTnjg9OVyD4f+IiUfgK4p3bE7r9p7jqSDLA==",
-      "requires": {
-        "@amplitude/types": "^0.3.2",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@amplitude/types": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@amplitude/types/-/types-0.3.2.tgz",
-      "integrity": "sha512-7+m7nhJMFGbpsppOUsCH8f4FOFyAxgKFuXkKknU/LP2CMYVjWEIoLTKKgaJPc2c8wXaK5KPXVetb8VeiGbuaGg=="
-    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -893,6 +879,14 @@
       "integrity": "sha512-BQ2HL/ZfiMm68Xdy7dkS49Vnnq+gSsxfOugJB4TA8Kmu4Ie9ZIa4K4VQYbcHxyW4ccg6l9VB57PjRA2RPh1elw==",
       "requires": {
         "decimal.js": "^10.2.0"
+      }
+    },
+    "amplitude": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/amplitude/-/amplitude-5.1.2.tgz",
+      "integrity": "sha512-9/k+8OH6whUSdA2580yCrF3DfnTQuFw0YfxSxRiK0Dh0+2ds/Iy18tUovZrLe3rouf/95EVArj6x9vYDPnFKKQ==",
+      "requires": {
+        "axios": "^0.19.2"
       }
     },
     "ansi-colors": {
@@ -4060,11 +4054,11 @@
       "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM="
     },
     "npm-groovy-lint": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-7.4.4.tgz",
-      "integrity": "sha512-Ca/VXSBJH2n7t9bbusD5OqdZlUjEwSjT+rRxlBu/nh7u//wa9yInp8lFytj1JsZHNX223acGCCay4YuMW9IxBQ==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-7.5.1.tgz",
+      "integrity": "sha512-BX2ZL0/d/phWoNhupvY2lZk6ky3+nqGIzVuNDf33KENOpny1qzkMjMtVSwaRsF2lXMe8x7iZBPjvrLTUjw6VxQ==",
       "requires": {
-        "@amplitude/node": "^0.3.3",
+        "amplitude": "^5.1.2",
         "ansi-colors": "^4.1.1",
         "axios": "^0.19.2",
         "cli-progress": "^3.6.0",

--- a/dependencies/package.json
+++ b/dependencies/package.json
@@ -16,7 +16,7 @@
     "htmlhint": "^0.14.1",
     "jsonlint": "^1.6.3",
     "markdownlint-cli": "^0.23.2",
-    "npm-groovy-lint": "^7.4.4",
+    "npm-groovy-lint": "^7.5.1",
     "prettier": "^2.1.1",
     "prettyjson": "^1.2.1",
     "sql-lint": "0.0.15",


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

Upgrade npm-groovy-lint dependency to 7.5.1, used for Groovy linting

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer 
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
