### PR TITLE
fix: comment typo for GH Container Registry

### DIFF
--- a/.github/workflows/deploy-RELEASE.yml
+++ b/.github/workflows/deploy-RELEASE.yml
@@ -54,9 +54,9 @@ jobs:
         shell: bash
         run: .automation/upload-docker.sh
 
-      #############################
-      # Run Deploy script for GPR #
-      #############################
+      ###################################################
+      # Run Deploy script for GitHub Container Registry #
+      ###################################################
       - name: Deploy Release image to GitHub Container Registry
         env:
           # Set the Env Vars


### PR DESCRIPTION
## Proposed Changes

1. Fixes the typo on `GPR`. I believe the original author wanted to type `GCR`.

My proposed change doesn't use `GCR` as this acronym has been generally used by the Google Container Registry. If you guys still want to use acronyms, then I suggest using `GHCR` (from your ghcr.io domain) to avoid conflicts with any existing accepted acronyms in the community.

I didn't touch other parts of the code that use `GCR` as an acronym but I can certainly do if you believe it's the right direction.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer 
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
