### PR TITLE
Making MULTI_STATUS honor DISABLE_ERRORS setting

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -988,17 +988,18 @@ CallStatusAPI() {
   else
     # Failure
     MESSAGE="${FAIL_MSG}"
-
-    # make sure we honor DISABLE_ERRORS
-    if [ "${DISABLE_ERRORS}" == "true" ]; then
-      STATUS="success"
-    fi
   fi
 
   ##########################################################
   # Check to see if were enabled for multi Status mesaages #
   ##########################################################
   if [ "${MULTI_STATUS}" == "true" ] && [ -n "${GITHUB_TOKEN}" ] && [ -n "${GITHUB_REPOSITORY}" ]; then
+
+    # make sure we honor DISABLE_ERRORS
+    if [ "${DISABLE_ERRORS}" == "true" ]; then
+      STATUS="success"
+    fi
+
     ##############################################
     # Call the status API to create status check #
     ##############################################

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -988,6 +988,11 @@ CallStatusAPI() {
   else
     # Failure
     MESSAGE="${FAIL_MSG}"
+
+    # make sure we honor DISABLE_ERRORS
+    if [ "${DISABLE_ERRORS}" == "true" ]; then
+      STATUS="success"
+    fi
   fi
 
   ##########################################################


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes unexpected behavior when `DISABLE_ERRORS=true`

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

If a user sets `DISABLE_ERRORS=true`, they are trying to make all linting checks succeed, such that PRs can be merged even with linter failures. Unfortunately `MULTI_STATUS` doesn't respect this setting, causing builds to go red even if `DISABLE_ERRORS=true`. (To make matters worse, MULTI_STATUS is enabled by default, so right now a user will have to explicitly disable MULTI_STATUS in order for DISABLE_ERRORS to work)

This adds a bit of logic into the `MULTI_STATUS` feature which will prevent the individual statuses from failing the build when `DISABLE_ERRORS=true`.


## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer 
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
