### PR TITLE
Print version, date and revision

### DIFF
--- a/.automation/upload-docker.sh
+++ b/.automation/upload-docker.sh
@@ -39,6 +39,7 @@ CONTAINER_URL=''                          # Final URL to upload
 # Dynamic build variables to pass to container when built #
 ###########################################################
 BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') # Current build date EX> "2017-08-28T09:24:41Z"
+BUILD_REVISION=$(git rev-parse --short HEAD)# Current git commit EX> "e89faa7"
 BUILD_VERSION=''                            # Current version of the container being built
 
 #########################
@@ -303,7 +304,7 @@ BuildImage() {
   ###################
   # Build the image #
   ###################
-  docker build --no-cache --build-arg "BUILD_DATE=${BUILD_DATE}" --build-arg "BUILD_VERSION=${BUILD_VERSION}" -t "${CONTAINER_URL}:${IMAGE_VERSION}" -f "${DOCKERFILE_PATH}" . 2>&1
+  docker build --no-cache --build-arg "BUILD_DATE=${BUILD_DATE}" --build-arg "BUILD_REVISION=${BUILD_REVISION}" --build-arg "BUILD_VERSION=${BUILD_VERSION}" -t "${CONTAINER_URL}:${IMAGE_VERSION}" -f "${DOCKERFILE_PATH}" . 2>&1
 
   #######################
   # Load the error code #
@@ -326,7 +327,7 @@ BuildImage() {
   ########################################################
   if [ ${UPDATE_MAJOR_TAG} -eq 1 ]; then
     # Tag the image with the major tag as well
-    docker build  --build-arg "BUILD_DATE=${BUILD_DATE}" --build-arg "BUILD_VERSION=${MAJOR_TAG}" -t "${CONTAINER_URL}:${MAJOR_TAG}" -f "${DOCKERFILE_PATH}" . 2>&1
+    docker build  --build-arg "BUILD_DATE=${BUILD_DATE}" --build-arg "BUILD_REVISION=${BUILD_REVISION}" --build-arg "BUILD_VERSION=${MAJOR_TAG}" -t "${CONTAINER_URL}:${MAJOR_TAG}" -f "${DOCKERFILE_PATH}" . 2>&1
 
     #######################
     # Load the error code #

--- a/.automation/upload-docker.sh
+++ b/.automation/upload-docker.sh
@@ -38,9 +38,9 @@ CONTAINER_URL=''                          # Final URL to upload
 ###########################################################
 # Dynamic build variables to pass to container when built #
 ###########################################################
-BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') # Current build date EX> "2017-08-28T09:24:41Z"
-BUILD_REVISION=$(git rev-parse --short HEAD)# Current git commit EX> "e89faa7"
-BUILD_VERSION=''                            # Current version of the container being built
+BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')   # Current build date EX> "2017-08-28T09:24:41Z"
+BUILD_REVISION=$(git rev-parse --short HEAD)  # Current git commit EX> "e89faa7"
+BUILD_VERSION=''                              # Current version of the container being built
 
 #########################
 # Source Function Files #
@@ -363,7 +363,7 @@ BuildImage() {
   ###################
   # Build the image #
   ###################
-  docker build --build-arg "BUILD_DATE=${BUILD_DATE}" --build-arg "BUILD_VERSION=${BUILD_VERSION}" -t "${ADDITONAL_URL}:${IMAGE_VERSION}" -f "${DOCKERFILE_PATH}" . 2>&1
+  docker build --build-arg "BUILD_DATE=${BUILD_DATE}" --build-arg "BUILD_REVISION=${BUILD_REVISION}" --build-arg "BUILD_VERSION=${BUILD_VERSION}" -t "${ADDITONAL_URL}:${IMAGE_VERSION}" -f "${DOCKERFILE_PATH}" . 2>&1
 
   #######################
   # Load the error code #
@@ -388,7 +388,7 @@ BuildImage() {
     ###################
     # Build the image #
     ###################
-    docker build --build-arg "BUILD_DATE=${BUILD_DATE}" --build-arg "BUILD_VERSION=${MAJOR_TAG}" -t "${ADDITONAL_URL}:${MAJOR_TAG}" -f "${DOCKERFILE_PATH}" . 2>&1
+    docker build --build-arg "BUILD_DATE=${BUILD_DATE}" --build-arg "BUILD_REVISION=${BUILD_REVISION}" --build-arg "BUILD_VERSION=${MAJOR_TAG}" -t "${ADDITONAL_URL}:${MAJOR_TAG}" -f "${DOCKERFILE_PATH}" . 2>&1
 
     #######################
     # Load the error code #

--- a/.automation/validate-docker-labels.sh
+++ b/.automation/validate-docker-labels.sh
@@ -9,10 +9,11 @@
 ###########
 GITHUB_WORKSPACE="${GITHUB_WORKSPACE}"  # GitHub Workspace
 GITHUB_SHA="${GITHUB_SHA}"              # Sha used to create this branch
-BUILD_DATE="${BUILD_DATE}"
-BUILD_REVISION="${GITHUB_SHA}"
-BUILD_VERSION="${GITHUB_SHA}"
-ERROR=0
+BUILD_DATE="${BUILD_DATE}"              # Date the container was built
+BUILD_REVISION="${GITHUB_SHA}"          # GitHub Sha
+BUILD_VERSION="${GITHUB_SHA}"           # Version of the container
+ORG_REPO="github/super-linter"          # Org/repo
+ERROR=0                                 # Error count
 
 #########################
 # Source Function Files #
@@ -33,17 +34,33 @@ Header() {
 ################################################################################
 #### Function ValidateLabel ####################################################
 ValidateLabel() {
-  LABEL=$(docker inspect --format "{{ index .Config.Labels \"$1\" }}" github/super-linter:"${GITHUB_SHA}")
-  if [[ ${LABEL} != "$2" ]]; then
-    error "Assert failed [$1 - '${LABEL}' != '$2']"
+  ##############
+  # Grab input #
+  ##############
+  CONTAINER_KEY="$1"    # Example: org.opencontainers.image.created
+  CONTAINER_VALUE="$2"  # Example: 1985-04-12T23:20:50.52Z
+
+  ########################
+  # Get the docker label #
+  ########################
+  LABEL=$(docker inspect --format "{{ index .Config.Labels \"${CONTAINER_KEY}\" }}" "${ORG_REPO}:${GITHUB_SHA}")
+
+  ###################
+  # Check the value #
+  ###################
+  if [[ ${LABEL} != "${CONTAINER_VALUE}" ]]; then
+    error "Assert failed [${CONTAINER_KEY} - '${LABEL}' != '${CONTAINER_VALUE}']"
     ERROR=1
   else
-    info "Assert passed [$1]"
+    info "Assert passed [${CONTAINER_KEY}]"
   fi
 }
 ################################################################################
 #### Function Footer ###########################################################
 Footer() {
+  #####################################
+  # Check if any errors were reported #
+  #####################################
   if [[ ${ERROR} -gt 0 ]]; then
     fatal "There were some failed assertions. See above"
   else

--- a/.automation/validate-docker-labels.sh
+++ b/.automation/validate-docker-labels.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+################################################################################
+############# Clean all code base for additonal testing @admiralawkbar #########
+################################################################################
+
+###########
+# Globals #
+###########
+GITHUB_WORKSPACE="${GITHUB_WORKSPACE}"  # GitHub Workspace
+GITHUB_SHA="${GITHUB_SHA}"              # Sha used to create this branch
+BUILD_DATE="${BUILD_DATE}"
+BUILD_REVISION="${GITHUB_SHA}"
+BUILD_VERSION="${GITHUB_SHA}"
+ERROR=0
+
+#########################
+# Source Function Files #
+#########################
+# shellcheck source=/dev/null
+source "${GITHUB_WORKSPACE}/lib/log.sh" # Source the function script(s)
+
+################################################################################
+############################ FUNCTIONS BELOW ###################################
+################################################################################
+################################################################################
+#### Function Header ###########################################################
+Header() {
+  info "--------------------------------------------------"
+  info "----- GitHub Actions validate docker labels ------"
+  info "--------------------------------------------------"
+}
+################################################################################
+#### Function ValidateLabel ####################################################
+ValidateLabel() {
+  LABEL=$(docker inspect --format "{{ index .Config.Labels \"$1\" }}" github/super-linter:"${GITHUB_SHA}")
+  if [[ ${LABEL} != "$2" ]]; then
+    error "Assert failed [$1 - '${LABEL}' != '$2']"
+    ERROR=1
+  else
+    info "Assert passed [$1]"
+  fi
+}
+################################################################################
+#### Function Footer ###########################################################
+Footer() {
+  if [[ ${ERROR} -gt 0 ]]; then
+    fatal "There were some failed assertions. See above"
+  else
+    info "-------------------------------------------------------"
+    info "The step has completed"
+    info "-------------------------------------------------------"
+  fi
+}
+################################################################################
+################################## MAIN ########################################
+################################################################################
+
+####################
+# Validate created #
+####################
+ValidateLabel "org.opencontainers.image.created" "${BUILD_DATE}"
+
+#####################
+# Validate revision #
+#####################
+ValidateLabel "org.opencontainers.image.revision" "${BUILD_REVISION}"
+
+####################
+# Validate version #
+####################
+ValidateLabel "org.opencontainers.image.version" "${BUILD_VERSION}"
+
+#################
+# Report status #
+#################
+Footer

--- a/.github/workflows/deploy-DEV.yml
+++ b/.github/workflows/deploy-DEV.yml
@@ -43,12 +43,18 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2.3.2
 
+      ########################
+      # Get the current date #
+      ########################
+      - name: Get current date
+        run: echo "::set-env name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
       ###################################
       # Build image locally for testing #
       ###################################
       - name: Build image
         shell: bash
-        run: docker build --no-cache -t github/super-linter:${GITHUB_SHA} .
+        run: docker build --build-arg "BUILD_DATE=${BUILD_DATE}" --build-arg "BUILD_REVISION=${GITHUB_SHA}" --build-arg "BUILD_VERSION=${GITHUB_SHA}" --no-cache -t github/super-linter:${GITHUB_SHA} .
 
       #####################################
       # Run Linter against Test code base #
@@ -70,3 +76,10 @@ jobs:
       - name: Run against all code base
         shell: bash
         run: docker run -e RUN_LOCAL=true -e OUTPUT_DETAILS=detailed -v ${GITHUB_WORKSPACE}:/tmp/lint github/super-linter:${GITHUB_SHA}
+
+      ########################################
+      # Validates the metadata docker labels #
+      ########################################
+      - name: Run Docker label test cases
+        shell: bash
+        run: .automation/validate-docker-labels.sh

--- a/.github/workflows/deploy-DEV.yml
+++ b/.github/workflows/deploy-DEV.yml
@@ -56,6 +56,13 @@ jobs:
         shell: bash
         run: docker build --build-arg "BUILD_DATE=${BUILD_DATE}" --build-arg "BUILD_REVISION=${GITHUB_SHA}" --build-arg "BUILD_VERSION=${GITHUB_SHA}" --no-cache -t github/super-linter:${GITHUB_SHA} .
 
+      ########################################
+      # Validates the metadata docker labels #
+      ########################################
+      - name: Run Docker label test cases
+        shell: bash
+        run: .automation/validate-docker-labels.sh
+
       #####################################
       # Run Linter against Test code base #
       #####################################
@@ -76,10 +83,3 @@ jobs:
       - name: Run against all code base
         shell: bash
         run: docker run -e RUN_LOCAL=true -e OUTPUT_DETAILS=detailed -v ${GITHUB_WORKSPACE}:/tmp/lint github/super-linter:${GITHUB_SHA}
-
-      ########################################
-      # Validates the metadata docker labels #
-      ########################################
-      - name: Run Docker label test cases
-        shell: bash
-        run: .automation/validate-docker-labels.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ FROM python:alpine
 # Get the build arguements #
 ############################
 ARG BUILD_DATE
+ARG BUILD_REVISION
 ARG BUILD_VERSION
 
 #########################################
@@ -39,12 +40,20 @@ LABEL com.github.actions.name="GitHub Super-Linter" \
       com.github.actions.color="red" \
       maintainer="GitHub DevOps <github_devops@github.com>" \
       org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.revision=$BUILD_REVISION \
       org.opencontainers.image.version=$BUILD_VERSION \
       org.opencontainers.image.authors="GitHub DevOps <github_devops@github.com>" \
       org.opencontainers.image.url="https://github.com/github/super-linter" \
       org.opencontainers.image.documentation="https://github.com/github/super-linter" \
       org.opencontainers.image.vendor="GitHub" \
       org.opencontainers.image.description="Lint your code base with GitHub Actions"
+
+#################################################
+# Set ENV values used for debugging the version #
+#################################################
+ENV BUILD_DATE=$BUILD_DATE
+ENV BUILD_REVISION=$BUILD_REVISION
+ENV BUILD_VERSION=$BUILD_VERSION
 
 ################################
 # Set ARG values used in Build #

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -437,6 +437,9 @@ Header() {
   ##########
   info "---------------------------------------------"
   info "--- GitHub Actions Multi Language Linter ----"
+  info " created date: ${BUILD_DATE}"
+  info " revision: ${BUILD_REVISION}"
+  info " version: ${BUILD_VERSION}"
   info "---------------------------------------------"
   info "---------------------------------------------"
   info "The Super-Linter source code can be found at:"

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -437,9 +437,9 @@ Header() {
   ##########
   info "---------------------------------------------"
   info "--- GitHub Actions Multi Language Linter ----"
-  info " created date: ${BUILD_DATE}"
-  info " revision: ${BUILD_REVISION}"
-  info " version: ${BUILD_VERSION}"
+  info " - Image Creation Date:[${BUILD_DATE}]"
+  info " - Image Revision:[${BUILD_REVISION}]"
+  info " - Image Version:[${BUILD_VERSION}]"
   info "---------------------------------------------"
   info "---------------------------------------------"
   info "The Super-Linter source code can be found at:"


### PR DESCRIPTION
Expose docker build arguments as environment variables to expose them when printing the header, the idea is to help to debug what's the version that has been used in case something bad happens (see https://github.com/github/super-linter/issues/672).

It has been added the git sha commit as a docker label metadata and also in the header

## Readiness Checklist

### Author/Contributor
- ~[ ] If documentation is needed for this change, has that been included in this pull request~

### Reviewing Maintainer 
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
