### PR TITLE
Make Super-Linter more famous with badge links on repos using it :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It is a simple combination of various linters, written in `bash`, to help valida
   - [Supported Linters](#supported-linters)
   - [How to use](#how-to-use)
     - [Example connecting GitHub Action Workflow](#example-connecting-github-action-workflow)
+    - [Add Super-Linter badge in your repository README](#add-super-linter-badge-in-your-repository-readme)
   - [Environment variables](#environment-variables)
     - [Template rules files](#template-rules-files)
   - [Disabling rules](#disabling-rules)
@@ -159,6 +160,26 @@ jobs:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+### Add Super-Linter badge in your repository README
+
+You can show Super-Linter status with a badge in your repository README
+
+[![GitHub Super-Linter](https://github.com/nvuillam/npm-groovy-lint/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/marketplace/actions/super-linter)
+
+Format:
+
+```markdown
+[![GitHub Super-Linter](https://github.com/<OWNER>/<REPOSITORY>/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/marketplace/actions/super-linter)
+```
+
+Example:
+
+```markdown
+[![GitHub Super-Linter](https://github.com/nvuillam/npm-groovy-lint/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/marketplace/actions/super-linter)
+```
+
+_Note:_ IF you did not use `Lint Code Base` as GitHub Action name, please read [GitHub Actions Badges documentation](https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository)
 
 ## Environment variables
 


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Add documentation for users to add a badge on their repos
Benefits: 
- Coders are happy to show their code is clean 😊 
- Coders not knowing GH Super Linter will know it after have clicked on a badge 👼 

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
