### PR TITLE
Fix list files function typos

### DIFF
--- a/lib/buildFileList.sh
+++ b/lib/buildFileList.sh
@@ -773,8 +773,8 @@ function PopulateShellScriptsList() {
   mapfile -t LIST_FILES < <(find "${GITHUB_WORKSPACE}" \
     -path "*/node_modules" -prune -o \
     -path "*/.git" -prune -o \
-    -path "*/.venv"-prune -o \
-    -path "*/.rbenv"-prune -o \
+    -path "*/.venv" -prune -o \
+    -path "*/.rbenv" -prune -o \
     -type f 2>&1)
   for FILE in "${LIST_FILES[@]}"; do
     if IsValidShellScript "${FILE}"; then

--- a/lib/worker.sh
+++ b/lib/worker.sh
@@ -180,19 +180,19 @@ function LintCodebase() {
       ######################################################
       # Make sure we don't lint node modules or test cases #
       ######################################################
-      if [[ ${DIR_NAME} == *"node_modules"* ]]; then
+      if [[ ${FILE} == *"node_modules"* ]]; then
         # This is a node modules file
         continue
-      elif [[ ${DIR_NAME} == *"${TEST_CASE_FOLDER}"* ]]; then
+      elif [[ ${FILE} == *"${TEST_CASE_FOLDER}"* ]]; then
         # This is the test cases, we should always skip
         continue
-      elif [[ ${DIR_NAME} == *".git" ]] || [[ ${FILE} == *".git" ]] || [[ ${FILE} == *".git/"* ]]; then
+      elif [[ ${FILE} == *".git" ]] || [[ ${FILE} == *".git/"* ]]; then
         # This is likely the .git folder and shouldn't be parsed
         continue
-      elif [[ ${DIR_NAME} == *".venv"* ]]; then
+      elif [[ ${FILE} == *".venv"* ]]; then
         # This is likely the python virtual environment folder and shouldn't be parsed
         continue
-      elif [[ ${DIR_NAME} == *".rbenv"* ]]; then
+      elif [[ ${FILE} == *".rbenv"* ]]; then
         # This is likely the ruby environment folder and shouldn't be parsed
         continue
       elif [[ ${FILE_TYPE} == "BASH" ]] && ! IsValidShellScript "${FILE}"; then

--- a/lib/worker.sh
+++ b/lib/worker.sh
@@ -100,8 +100,8 @@ function LintCodebase() {
       mapfile -t LIST_FILES < <(find "${GITHUB_WORKSPACE}" \
         -path "*/node_modules" -prune -o \
         -path "*/.git" -prune -o \
-        -path "*/.venv"-prune -o \
-        -path "*/.rbenv"-prune -o \
+        -path "*/.venv" -prune -o \
+        -path "*/.rbenv" -prune -o \
         -type f -regex "${FILE_EXTENSIONS}" 2>&1)
 
       ###########################


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #704

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Fix typos in the `find` query when building the list of files to lint.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
