### PR TITLE
Fixed a typo in linter.sh code comments

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -59,7 +59,7 @@ GROOVY_FILE_NAME='.groovylintrc.json'                               # Name of th
 GROOVY_LINTER_RULES="${DEFAULT_RULES_LOCATION}/${GROOVY_FILE_NAME}" # Path to the Groovy lint rules
 # HTML Vars
 HTML_FILE_NAME='.htmlhintrc'                                    # Name of the file
-HTML_LINTER_RULES="${DEFAULT_RULES_LOCATION}/${HTML_FILE_NAME}" # Path to the CSS lint rules
+HTML_LINTER_RULES="${DEFAULT_RULES_LOCATION}/${HTML_FILE_NAME}" # Path to the HTML lint rules
 # Java Vars
 JAVA_FILE_NAME="sun_checks.xml"                                 # Name of the Java config file
 JAVA_LINTER_RULES="${DEFAULT_RULES_LOCATION}/${JAVA_FILE_NAME}" # Path to the Java lint rules


### PR DESCRIPTION
Hi folks :wave:

I was reading linter.sh to learn more about how super-linter works, and I found a typo in the code comments for the ``HTML_LINTER_RULES`` variable. The code comments referred to the ``HTML_LINTER_RULES`` variable as being the path to the CSS lint rules rather than being the path to the HTML lint rules, so I went ahead and fixed that typo.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

Replaced the term "CSS" with "HTML" in code comments for the HTML_LINTER_RULES variable.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
