### PR TITLE
Update black version

### DIFF
--- a/dependencies/Pipfile.lock
+++ b/dependencies/Pipfile.lock
@@ -58,7 +58,7 @@
                 "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
             ],
             "index": "pypi",
-            "version": "==19.10b0"
+            "version": "==20.8b1"
         },
         "boto3": {
             "hashes": [

--- a/dependencies/Pipfile.lock
+++ b/dependencies/Pipfile.lock
@@ -286,6 +286,13 @@
             ],
             "version": "==5.0.7"
         },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+            ],
+            "version": "==0.4.3"
+        },
         "networkx": {
             "hashes": [
                 "sha256:7978955423fbc9639c10498878be59caf99b44dc304c2286162fd24b458c1602",
@@ -505,6 +512,14 @@
                 "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
             ],
             "version": "==1.4.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
+                "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
+                "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
+            ],
+            "version": "==3.7.4.3"
         },
         "urllib3": {
             "hashes": [

--- a/dependencies/Pipfile.lock
+++ b/dependencies/Pipfile.lock
@@ -54,8 +54,8 @@
         },
         "black": {
             "hashes": [
-                "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
-                "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
+                "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea",
+                "sha256:70b62ef1527c950db59062cda342ea224d772abdf6adc58b86a45421bab20a6b"
             ],
             "index": "pypi",
             "version": "==20.8b1"


### PR DESCRIPTION
Hi,

https://github.com/github/super-linter/commit/8ac1c99a2e5d1fa498a07f9734b2ac321a53429c downgraded black. As a result, [`v3.10.0`](https://github.com/github/super-linter/releases/tag/v3.10.0) broke existing workflow (ex: https://github.com/crytic/slither/pull/636#issuecomment-692148032). This PR restores black to its latest [available version](https://pypi.org/project/black).

Fixes #722

## Proposed Changes

- Use black `20.8b1` instead of `19.10b0`

## Readiness Checklist

### Author/Contributor
- [X] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
