### PR TITLE
Fix ERROR_ON_MISSING_EXEC_BIT initialization

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -257,7 +257,7 @@ DEFAULT_IFS="${IFS}"                                # Get the Default IFS for up
 ###############################################################
 DEFAULT_DISABLE_ERRORS='false'                          # Default to enabling errors
 export DEFAULT_DISABLE_ERRORS                           # Workaround SC2034
-ERROR_ON_MISSING_EXEC_BIT='false'                       # Default to report a warning if a shell script doesn't have the executable bit set to 1
+ERROR_ON_MISSING_EXEC_BIT="${ERROR_ON_MISSING_EXEC_BIT:-false}" # Default to report a warning if a shell script doesn't have the executable bit set to 1
 export ERROR_ON_MISSING_EXEC_BIT
 RAW_FILE_ARRAY=()                                       # Array of all files that were changed
 export RAW_FILE_ARRAY                                   # Workaround SC2034

--- a/lib/worker.sh
+++ b/lib/worker.sh
@@ -297,6 +297,7 @@ function LintCodebase() {
       # Check the shell for errors #
       ##############################
       if [ ${ERROR_CODE} -ne 0 ]; then
+        debug "Found errors. Error code: ${ERROR_CODE}, File type: ${FILE_TYPE}, Error on missing exec bit: ${ERROR_ON_MISSING_EXEC_BIT}"
         if [[ ${FILE_TYPE} == "BASH_EXEC" ]] && [[ "${ERROR_ON_MISSING_EXEC_BIT}" == "false" ]]; then
           ########
           # WARN #


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes N/A

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Fix the initialization of the `ERROR_ON_MISSING_EXEC_BIT` variable. We were not picking an eventually set value from the environment.
2. Add a debug statement to print the values of `ERROR_CODE`, `FILE_TYPE`, and `ERROR_ON_MISSING_EXEC_BIT`

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
