### PR TITLE
Lint all changed files with editorconfig-checker

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -1542,7 +1542,7 @@ if [ "${VALIDATE_EDITORCONFIG}" == "true" ]; then
   # Lint the files with editorconfig #
   ####################################
   # LintCodebase "FILE_TYPE" "LINTER_NAME" "LINTER_CMD" "FILE_TYPES_REGEX" "FILTER_REGEX_INCLUDE" "FILTER_REGEX_EXCLUDE" "FILE_ARRAY"
-  LintCodebase "EDITORCONFIG" "editorconfig-checker" "editorconfig-checker" "^.*$" "${FILTER_REGEX_INCLUDE}" "${FILTER_REGEX_EXCLUDE}" "${FILE_ARRAY_ENV[@]}"
+  LintCodebase "EDITORCONFIG" "editorconfig-checker" "editorconfig-checker" "^.*$" "${FILTER_REGEX_INCLUDE}" "${FILTER_REGEX_EXCLUDE}" "${RAW_FILE_ARRAY[@]}"
 fi
 
 ###############


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Lint _all_ changed files with editorconfig-checker, not just files that were detected to have the "ENV" type. Using the FILE_ARRAY_ENV seemed like a mistake honestly, I'm not sure why those files specifically should be checked against the .editorconfig. For example, previously editorconfig-checker would not be run against Javascript files if the VALIDATE_ALL_CODEBASE variable was set to false, but it would it if was set to true.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
