### PR TITLE
Ignore .git and symlink .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ typings/
 
 # default output report
 super-linter.report
+
+# Git directory (useful for .dockerignore)
+.git


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Create a symbolic link to `.gitignore` named `.dockerignore`, so that we don't have to repeat ourselves.
1. Ignore the `.git` directory, so that it's ignored by the Docker daemon when building the container, because of the symbolic link above. This saves about 15-20 seconds of build time (the .git directory is currently about 20 MB in size).

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
