### PR TITLE
Sort environment variables when printing debug info

### DIFF
--- a/lib/validation.sh
+++ b/lib/validation.sh
@@ -212,7 +212,7 @@ function GetValidationInfo() {
   debug "---------------------------------------------"
   RUNNER=$(whoami)
   debug "Runner:[${RUNNER}]"
-  PRINTENV=$(printenv)
+  PRINTENV=$(printenv | sort)
   debug "ENV:"
   debug "${PRINTENV}"
   debug "---------------------------------------------"


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Sort the environment variables when printing them with `printenv`. This makes debugging easier, because you don't have to manually scan the whole list looking for the variable you need to check.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
