### PR TITLE
Remove unnecessary --update for apk in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ ARG GLIBC_VERSION='2.31-r0'
 ####################
 # Run APK installs #
 ####################
-RUN apk add --update --no-cache \
+RUN apk add --no-cache \
     ansible-lint \
     bash \
     coreutils \
@@ -263,7 +263,7 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 #################################################
 # Basic setup, programs and init
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories \
-    && apk add --update --no-cache rakudo zef
+    && apk add --no-cache rakudo zef
 
 ######################
 # Install CheckStyle #


### PR DESCRIPTION
There are two `apk add` use both `--update` and `--no-cache` parameter,
which is unnecessary, usually should use only `--no-cache` to prevent
leaving cache files, just like the other `apk add` in line 249

## Proposed Changes

Remove unnecessary --update for apk in Dockerfile

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
