### PR TITLE
Fix probable typo in .markdown-lint.yml

### DIFF
--- a/TEMPLATES/.markdown-lint.yml
+++ b/TEMPLATES/.markdown-lint.yml
@@ -22,7 +22,7 @@ MD004: false                  # Unordered list style
 MD007:
   indent: 2                   # Unordered list indentation
 MD013:
-  line_length: 808            # Line length
+  line_length: 80             # Line length
 MD026:
   punctuation: ".,;:!。，；:"  # List of not allowed
 MD029: false                  # Ordered list item prefix


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #816

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Replace `808` with `80`

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
