### PR TITLE
ignore kustomize file with kubeval

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -559,12 +559,7 @@ DetectKubernetesFile() {
   FILE="${1}" # File that we need to validate
   debug "Checking if ${FILE} is a Kubernetes descriptor..."
 
-  if grep -q -E 'apiVersion:\s*kustomize.config.k8s.io' "${FILE}" >/dev/null; then
-    debug "${FILE} is NOT a Kubernetes descriptor (Kustomize only)"
-    return 1
-  fi
-
-  if grep -q -E '(apiVersion):' "${FILE}" >/dev/null; then
+  if grep -v 'kustomize.config.k8s.io' "${FILE}" | grep -q -E '(apiVersion):'; then
     debug "${FILE} is a Kubernetes descriptor"
     return 0
   fi

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -559,6 +559,11 @@ DetectKubernetesFile() {
   FILE="${1}" # File that we need to validate
   debug "Checking if ${FILE} is a Kubernetes descriptor..."
 
+  if grep -q -E 'apiVersion:\s*kustomize.config.k8s.io' "${FILE}" >/dev/null; then
+    debug "${FILE} is NOT a Kubernetes descriptor (Kustomize only)"
+    return 1
+  fi
+
   if grep -q -E '(apiVersion):' "${FILE}" >/dev/null; then
     debug "${FILE} is a Kubernetes descriptor"
     return 0


### PR DESCRIPTION
currently, kubeval doesn't support kustomize file

so kubeval returns a false-positive about a missing `metadata` key:
```
2020-10-09 06:19:19 [ERROR ]   Found errors in [kubeval] linter!
2020-10-09 06:19:19 [ERROR ]   [ERR  - .../kustomization.yml: Missing 'metadata' key]
2020-10-09 06:19:19 [ERROR ]   Linter CMD:[kubeval --strict .../kustomization.yml]
```

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
