### PR TITLE
Fetch full git history to get a proper list of changed files within super-linter

### DIFF
--- a/.github/workflows/stack-linter.yml
+++ b/.github/workflows/stack-linter.yml
@@ -37,6 +37,9 @@ jobs:
       ##########################
       - name: Checkout Code
         uses: actions/checkout@v2.3.3
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
 
       ################################
       # Run Linter against code base #

--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ jobs:
       ##########################
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
 
       ################################
       # Run Linter against code base #


### PR DESCRIPTION
This is an update to documentation with a solution I've found to fix the issue described in #671. For the explanation please see the sample PR I created https://github.com/dec5e/super-linter-test/pull/4. Quoting important part:

> The problems seems to be in the way the code is fetched by `actions/checkout@v2` which fetches only 1 last commit by default. When I do the same locally and then do `git diff master...feature-branch` (as `super-linter` does) the command fails for me completely. Not sure why `super-linter` is not failing but it doesn't work correct either. Fetching entire git history with `actions/checkout@v2` fixes the issue.

So this looks to me like an (inconvenient) feature in a dependency action which prevents `super-linter` action to work correctly on Github. As a workaround I suggest to fetch full git history with `actions/checkout@v2`.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->


<!-- Describe what the changes are -->

## Proposed Changes

1. Update documentation
2. Update local workflow

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
