### PR TITLE
Pinned Black version to >=20 in Pipfile

### DIFF
--- a/dependencies/Pipfile
+++ b/dependencies/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-black = "*"
+black = ">=20"
 cfn-lint = "*"
 flake8 = "*"
 pylint = "*"


### PR DESCRIPTION
Pinned Black version to >=20.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
https://github.com/github/super-linter/issues/807
<!-- markdownlint-disable -->

Fixes #

Pinned version of Black formatter in Pipfile to >=20 so that it doesn't throw errors for projects using newer Black versions.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Pin Black version in the Pipfile

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
