### PR TITLE
Install stylelint-scss

### DIFF
--- a/dependencies/package.json
+++ b/dependencies/package.json
@@ -23,6 +23,7 @@
     "standard": "^14.3.4",
     "stylelint": "^13.7.2",
     "stylelint-config-standard": "^20.0.0",
+    "stylelint-scss": "^3.18.0",
     "typescript": "^4.0.3",
     "tekton-lint": "^0.4.3"
   }


### PR DESCRIPTION
## Proposed Changes

1. Install [stylelint-scss](https://github.com/kristerkari/stylelint-scss) to allow enabling SCSS rules when running stylelint.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
