### PR TITLE
Fixed typo in missing linter rule fatal error.

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -435,7 +435,7 @@ GetLinterRules() {
     debug "  -> ${LANGUAGE_LINTER_RULES} rules file (${!LANGUAGE_LINTER_RULES}) exists."
   else
     # Here we expect a rules file, so fail if not available.
-    fatal "  -> ${LANGUAGE_LINTER_RULES} rules file (${!LANGUAGE_LINTER_RULES}) doesn't exists. Terminating..."
+    fatal "  -> ${LANGUAGE_LINTER_RULES} rules file (${!LANGUAGE_LINTER_RULES}) doesn't exist. Terminating..."
   fi
 
   eval "export ${LANGUAGE_LINTER_RULES}"


### PR DESCRIPTION
## Fixes

Fixes a small typo when a linter rule is not found.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
