### PR TITLE
Add missing dotnet and R dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,7 @@ RUN apk add --no-cache \
     jq \
     krb5-libs \
     libc-dev libxml2-dev libxml2-utils libgcc \
+    lttng-ust-dev \
     libcurl libintl libssl1.1 libstdc++ \
     linux-headers \
     make \
@@ -103,9 +104,10 @@ RUN apk add --no-cache \
     php7 php7-phar php7-json php7-mbstring php-xmlwriter \
     php7-tokenizer php7-ctype php7-curl php7-dom php7-simplexml \
     py3-setuptools \
-    R \
+    R R-dev R-doc \
     readline-dev \
-    ruby ruby-dev ruby-bundler ruby-rdoc
+    ruby ruby-dev ruby-bundler ruby-rdoc \
+    zlib zlib-dev
 
 ########################################
 # Copy dependencies files to container #


### PR DESCRIPTION
# Proposed Changes

1. Add missing dotNet dependencies: `zlib`, `zlib-dev` and `lttng-ust-dev`
1. Add missing R dependencies: `R-dev` `R-doc`, as suggested by the R installer:

>     - If you want to install R packages from CRAN that contains native extensions, then you must also install R-dev.
>     - To avoid warnings about R.css when installing R extensions also install R-doc.

This fixes warning during the installation of dotNet:

```shell
dotnet_install: Warning: Unable to locate zlib. Probable prerequisite missing; install zlib.
dotnet_install: Warning: Unable to locate liblttng. Probable prerequisite missing; install liblttng.
```

and warnings during the installation of R:

```shell
** help
No man pages found in package  ‘translations’ 
*** installing help indices
Warning in file.copy(file.path(R.home("doc"), "html", "R.css"), outman) :
  problem copying /usr/share/doc/R/html/R.css to /usr/lib/R/library/00LOCK-translations/00new/translations/html/R.css: No such file or directory
```

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
