### PR TITLE
bugfix: #900

### DIFF
--- a/lib/buildFileList.sh
+++ b/lib/buildFileList.sh
@@ -61,12 +61,12 @@ function BuildFileList() {
       # print header #
       ################
       debug "----------------------------------------------"
-      debug "Generating Diff with:[git diff-tree --no-commit-id --name-only -r ${GITHUB_SHA}]"
+      debug "Generating Diff with:[git diff-tree --no-commit-id --name-only -r \"${GITHUB_SHA}]\""
 
       #################################################
       # Get the Array of files changed in the commits #
       #################################################
-      mapfile -t RAW_FILE_ARRAY < <(git diff-tree --no-commit-id --name-only -r ${GITHUB_SHA} 2>&1)
+      mapfile -t RAW_FILE_ARRAY < <(git diff-tree --no-commit-id --name-only -r "${GITHUB_SHA}" 2>&1)
     else
       ################
       # PR event     #

--- a/lib/buildFileList.sh
+++ b/lib/buildFileList.sh
@@ -53,16 +53,35 @@ function BuildFileList() {
       fatal "[${SWITCH_CMD}]"
     fi
 
-    ################
-    # print header #
-    ################
-    debug "----------------------------------------------"
-    debug "Generating Diff with:[git diff --name-only '${DEFAULT_BRANCH}...${GITHUB_SHA}' --diff-filter=d]"
+    if [ "${GITHUB_EVENT_NAME}" == "push" ]; then
+      ################
+      # push event   #
+      ################
+      ################
+      # print header #
+      ################
+      debug "----------------------------------------------"
+      debug "Generating Diff with:[git diff-tree --no-commit-id --name-only -r ${GITHUB_SHA}]"
 
-    #################################################
-    # Get the Array of files changed in the commits #
-    #################################################
-    mapfile -t RAW_FILE_ARRAY < <(git -C "${GITHUB_WORKSPACE}" diff --name-only "${DEFAULT_BRANCH}...${GITHUB_SHA}" --diff-filter=d 2>&1)
+      #################################################
+      # Get the Array of files changed in the commits #
+      #################################################
+      mapfile -t RAW_FILE_ARRAY < <(git diff-tree --no-commit-id --name-only -r ${GITHUB_SHA} 2>&1)
+    else
+      ################
+      # PR event     #
+      ################
+      ################
+      # print header #
+      ################
+      debug "----------------------------------------------"
+      debug "Generating Diff with:[git diff --name-only '${DEFAULT_BRANCH}...${GITHUB_SHA}' --diff-filter=d]"
+
+      #################################################
+      # Get the Array of files changed in the commits #
+      #################################################
+      mapfile -t RAW_FILE_ARRAY < <(git -C "${GITHUB_WORKSPACE}" diff --name-only "${DEFAULT_BRANCH}...${GITHUB_SHA}" --diff-filter=d 2>&1)
+    fi
   else
     WORKSPACE_PATH="${GITHUB_WORKSPACE}"
     if [ "${TEST_CASE_RUN}" == "true" ]; then


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #900

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

Problem:
There is no differentiation between push and PR event type in BuildFileList function. File list gets empty when git commit pushes to DEFAULT_BRANCH.

Solution:
Make difference between push and PR requests to craft file list depends on request type

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [X] Label as `bug`
