### PR TITLE
README Improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ It is a simple combination of various linters, written in `bash`, to help valida
     - [Add Super-Linter badge in your repository README](#add-super-linter-badge-in-your-repository-readme)
   - [Environment variables](#environment-variables)
     - [Template rules files](#template-rules-files)
+    - [Using your own rules files](#using-your-own-rules-files)
   - [Disabling rules](#disabling-rules)
   - [Filter linted files](#filter-linted-files)
   - [Docker Hub](#docker-hub)
@@ -296,7 +297,11 @@ You can use the **GitHub** **Super-Linter** _with_ or _without_ your own persona
 - Copy **any** or **all** template rules files from `TEMPLATES/` into your repository in the location: `.github/linters/` of your repository
   - If your repository does not have rules files, they will fall back to defaults in [this repository's `TEMPLATE` folder](https://github.com/github/super-linter/tree/master/TEMPLATES)
 
-## Disabling rules
+### Using your own rules files
+
+If your repository contains your own rules files that live outside of a ``.github/linters/`` directory, you will have to tell Super-Linter where your rules files are located in your repository, and what their file names are. To learn more, see [Using your own rules files](docs/using-rules-files.md).
+
+### Disabling rules
 
 If you need to disable certain _rules_ and _functionality_, you can view [Disable Rules](https://github.com/github/super-linter/blob/master/docs/disabling-linters.md)
 

--- a/docs/using-rules-files.md
+++ b/docs/using-rules-files.md
@@ -1,23 +1,8 @@
 # Using your own rules files
 
-If your repository contains your own rules files that live outside of a ``.github/linters/`` directory, you will have to tell Super-Linter where your rules files are located in your repository, and what their file names are.
+If your repository contains your own rules files that live outside of a ``.github/linters/`` directory, you will have to tell Super-Linter where your rules files are located in your repository, and what their filenames are.
 
-You can tell Super-Linter where your rules files are located with the ``LINTER_RULES_PATH`` ENV VAR, and you can tell Super-Linter what their file names are by using any of the ENV VARS from the table below. 
-
-| ENV VARS that can be used with LINTER_RULES_PATH |
-| --------------------------------- |
-| CSS_FILE_NAME                     |
-| DOCKERFILE_HADOLINT_FILE_NAME     |
-| EDITORCONFIG_FILE_NAME            |
-| JAVASCRIPT_ES_CONFIG_FILE         |
-| MARKDOWN_CONFIG_FILE              |
-| PYTHON_PYLINT_CONFIG_FILE         |
-| PYTHON_FLAKE8_CONFIG_FILE         |
-| PYTHON_BLACK_CONFIG_FILE          |
-| RUBY_CONFIG_FILE                  |
-| SNAKEMAKE_SNAKEFMT_CONFIG_FILE    |
-| TYPESCRIPT_ES_CONFIG_FILE         |
-| JAVASCRIPT_ES_LINTER_RULES        |
+You can tell Super-Linter where your rules files are located with the ``LINTER_RULES_PATH`` ENV VAR, and you can tell Super-Linter what their filenames are by using any of the filename ENV VARS listed in the [Environment variables table](/README.md#Environment-variables). You can determine which ENV VARS are filename ENV VARS by looking in the notes column for the term "filename."
 
 ### Here is an example
 

--- a/docs/using-rules-files.md
+++ b/docs/using-rules-files.md
@@ -1,0 +1,45 @@
+# Using your own rules files
+
+If your repository contains your own rules files that live outside of a ``.github/linters/`` directory, you will have to tell Super-Linter where your rules files are located in your repository, and what their file names are.
+
+You can tell Super-Linter where your rules files are located with the ``LINTER_RULES_PATH`` ENV VAR, and you can tell Super-Linter what their file names are by using any of the ENV VARS from the table below. 
+
+| ENV VARS that can be used with LINTER_RULES_PATH |
+| --------------------------------- |
+| CSS_FILE_NAME                     |
+| DOCKERFILE_HADOLINT_FILE_NAME     |
+| EDITORCONFIG_FILE_NAME            |
+| JAVASCRIPT_ES_CONFIG_FILE         |
+| MARKDOWN_CONFIG_FILE              |
+| PYTHON_PYLINT_CONFIG_FILE         |
+| PYTHON_FLAKE8_CONFIG_FILE         |
+| PYTHON_BLACK_CONFIG_FILE          |
+| RUBY_CONFIG_FILE                  |
+| SNAKEMAKE_SNAKEFMT_CONFIG_FILE    |
+| TYPESCRIPT_ES_CONFIG_FILE         |
+| JAVASCRIPT_ES_LINTER_RULES        |
+
+### Here is an example
+
+Below is an example of how to configure the ``env`` section of Super-Linter's ``linter.yml`` to lint JavaScript and CSS code using ``eslint`` and ``stylelint`` with your own ``.eslintrc.json`` and ``.stylelintrc.json`` rules files that are located in the root directory of your repository.  
+
+``` yaml
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          LINTER_RULES_PATH: /
+          CSS_FILE_NAME: .styelintrc.json
+          JAVASCRIPT_ES_CONFIG_FILE: .eslintrc.json
+          VALIDATE_CSS: true
+          VALIDATE_JAVASCRIPT_ES: true
+```
+
+The above example tells Super-Linter:
+
+a) Your rules files are located in your repository's root directory using the ``LINTER_RULES_PATH: /`` ENV VAR.
+
+b) Your eslint and stylelint rules files are named ``.stylelintrc.json`` and ``.eslintrc.json`` using the ``CSS_FILE_NAME: .styelintrc.json`` and ``JAVASCRIPT_ES_CONFIG_FILE: .eslintrc.json`` ENV VARS.
+
+c) To use ``stylelint`` and ``eslint`` to lint all CSS and JavaScript code using the ``VALIDATE_CSS: true`` and ``VALIDATE_JAVASCRIPT_ES: true`` ENV VARS.

--- a/docs/using-rules-files.md
+++ b/docs/using-rules-files.md
@@ -4,7 +4,7 @@ If your repository contains your own rules files that live outside of a ``.githu
 
 You can tell Super-Linter where your rules files are located with the ``LINTER_RULES_PATH`` ENV VAR, and you can tell Super-Linter what their filenames are by using any of the filename ENV VARS listed in the [Environment variables table](/README.md#Environment-variables). You can determine which ENV VARS are filename ENV VARS by looking in the notes column for the term "filename."
 
-### Here is an example
+## Here is an example
 
 Below is an example of how to configure the ``env`` section of Super-Linter's ``linter.yml`` to lint JavaScript and CSS code using ``eslint`` and ``stylelint`` with your own ``.eslintrc.json`` and ``.stylelintrc.json`` rules files that are located in the root directory of your repository.  
 


### PR DESCRIPTION
Hi folks,

I added some clarity to the README that may help developers new to super-linter avoid running into issues #864 and #685. I added a "Using your own rules" section under the "Template rules" section in the README. This new section talks about how users can configure super-linter to use their own rules files if their rules files live outside of a .github/linters directory in their repo. 

I hope that this helps, or is at least a starting point that turns into documentation that helps with this issue. If anyone has any suggestions feel free to add them 😃 

cc: @pdelre, @PhunStyle, @ferrarimarco

#Fixes #864 
#Fixes #872 

### Author/Contributor
- [X] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
