### PR TITLE
Fail on errors while getting linter versions

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -281,11 +281,10 @@ for LANGUAGE in "${LANGUAGE_ARRAY[@]}"; do
 
   if ! command -v "${LINTER_NAME}" 1&>/dev/null 2>&1; then
     # Failed
-    error "Failed to find [${LINTER_NAME}] in system!"
-    fatal "[${VALIDATE_INSTALL_CMD}]"
+    fatal "Failed to find [${LINTER_NAME}] in system!"
   else
     # Success
-    debug "Successfully found binary for ${F[W]}[${LINTER_NAME}]${F[B]} in system location: ${F[W]}[${VALIDATE_INSTALL_CMD}]"
+    debug "Successfully found binary for ${F[W]}[${LINTER_NAME}]${F[B]}."
   fi
 done
 


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #937 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Fail if the are errors when getting linter versions. `mapfile` was swallowing the error code, so any errors got past the validation.
1. Add a workaround for https://github.com/zaach/jsonlint/issues/122 which should be removed as soon as that issue is resolved. TLDR: `jsonlint --version` returns `1`.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
