### PR TITLE
Use the already-defined linter names array to print linter versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -340,7 +340,7 @@ COPY TEMPLATES /action/lib/.automation
 ###################################
 # Run to build file with versions #
 ###################################
-RUN /action/lib/linterVersions.sh
+RUN ACTIONS_RUNNER_DEBUG=true WRITE_LINTER_VERSIONS_FILE=true /action/lib/linter.sh
 
 ##################################4
 # Run validations of built image #

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -324,6 +324,18 @@ GetLinterVersions() {
   debug "---------------------------------------------"
   debug "Linter Version Info:"
 
+  if ! [ -e "${VERSION_FILE}" ] && [ "${WRITE_LINTER_VERSIONS_FILE}" = "true" ]; then
+    debug "Building linter version file..."
+    # shellcheck source=/dev/null
+    source /action/lib/linterVersions.sh # Source the function script(s)
+    if BuildLinterVersions "${VERSION_FILE}" "${LINTER_NAMES_ARRAY[@]}"; then
+      info "Linter version file built correctly."
+      exit
+    else
+      fatal "Error while building the versions file."
+    fi
+  fi
+
   ################################
   # Cat the linter versions file #
   ################################
@@ -339,7 +351,7 @@ GetLinterVersions() {
   ##############################
   if [ ${ERROR_CODE} -ne 0 ]; then
     # Failure
-    warn "Failed to view version file:[${VERSION_FILE}]"
+    fatal "Failed to view version file:[${VERSION_FILE}]"
   else
     # Success
     debug "${CAT_CMD}"
@@ -1162,6 +1174,11 @@ if [ -n "${OUTPUT_FORMAT}" ]; then
   fi
 fi
 
+##################################
+# Get and print all version info #
+##################################
+GetLinterVersions
+
 #######################
 # Get GitHub Env Vars #
 #######################
@@ -1261,11 +1278,6 @@ for i in "${!LINTER_COMMANDS_ARRAY[@]}"; do
   debug "Linter key: $i, command: ${LINTER_COMMANDS_ARRAY[$i]}"
 done
 debug "---------------------------------------------"
-
-##################################
-# Get and print all version info #
-##################################
-GetLinterVersions
 
 ###########################################
 # Build the list of files for each linter #

--- a/lib/linterVersions.sh
+++ b/lib/linterVersions.sh
@@ -4,7 +4,7 @@ BuildLinterVersions() {
   VERSION_FILE="${1}" && shift
   LINTER_ARRAY=("$@")
 
-  debug "Building linter version file ${VERSION_FILE} for the following linters: ${LINTER_ARRAY}..."
+  debug "Building linter version file ${VERSION_FILE} for the following linters: ${LINTER_ARRAY[*]}..."
 
   ##########################################################
   # Go through the array of linters and print version info #

--- a/lib/linterVersions.sh
+++ b/lib/linterVersions.sh
@@ -1,49 +1,10 @@
 #!/usr/bin/env bash
 
-################################################################################
-################################################################################
-########### Super-Linter (Get the linter versions) @admiralawkbar ##############
-################################################################################
-################################################################################
-
-###########
-# Globals #
-###########
-(( LOG_TRACE=LOG_DEBUG=LOG_VERBOSE=LOG_NOTICE=LOG_WARN=LOG_ERROR="true" )) # Enable all loging
-export LOG_TRACE LOG_DEBUG LOG_VERBOSE LOG_NOTICE LOG_WARN LOG_ERROR
-
-#########################
-# Source Function Files #
-#########################
-# shellcheck source=/dev/null
-source /action/lib/log.sh # Source the function script(s)
-
-###########
-# GLOBALS #
-###########
-VERSION_FILE='/action/lib/linter-versions.txt'  # File to store linter versions
-ARM_TTK_PSD1='/usr/bin/arm-ttk'                 # Powershell var
-
-#######################################
-# Linter array for information prints #
-#######################################
-LINTER_ARRAY=('ansible-lint' 'arm-ttk' 'asl-validator' 'bash-exec' 'black' 'cfn-lint' 'checkstyle' 'chktex' 'clj-kondo' 'coffeelint'
-  'dotnet-format' 'dart' 'dockerfilelint' 'dotenv-linter' 'editorconfig-checker' 'eslint' 'flake8' 'golangci-lint'
-  'hadolint' 'htmlhint' 'isort' 'jsonlint' 'kubeval' 'ktlint' 'lintr' 'lua' 'markdownlint' 'npm-groovy-lint' 'perl' 'protolint'
-  'pwsh' 'pylint' 'raku' 'rubocop' 'shellcheck' 'shfmt' 'spectral' 'standard' 'stylelint' 'sql-lint'
-  'tekton-lint' 'terrascan' 'tflint' 'xmllint' 'yamllint')
-
-################################################################################
-########################## FUNCTIONS BELOW #####################################
-################################################################################
-################################################################################
-#### Function BuildLinterVersions ##############################################
 BuildLinterVersions() {
-  #########################
-  # Print version headers #
-  #########################
-  info "---------------------------------------------"
-  info "Linter Version Info:"
+  VERSION_FILE="${1}" && shift
+  LINTER_ARRAY=("$@")
+
+  debug "Building linter version file ${VERSION_FILE} for the following linters: ${LINTER_ARRAY}..."
 
   ##########################################################
   # Go through the array of linters and print version info #
@@ -55,7 +16,7 @@ BuildLinterVersions() {
       ####################
       if [[ ${LINTER} == "arm-ttk" ]]; then
         # Need specific command for ARM
-        GET_VERSION_CMD="$(grep -iE 'version' "${ARM_TTK_PSD1}" | xargs 2>&1)"
+        GET_VERSION_CMD="$(grep -iE 'version' "/usr/bin/arm-ttk" | xargs 2>&1)"
       elif [[ ${LINTER} == "protolint" ]] || [[ ${LINTER} == "editorconfig-checker" ]] || [[ ${LINTER} == "bash-exec" ]]; then
         # Need specific command for Protolint and editorconfig-checker
         GET_VERSION_CMD="$(echo "--version not supported")"
@@ -90,31 +51,25 @@ BuildLinterVersions() {
       ##############################
       debug "Linter version for ${LINTER}: ${GET_VERSION_CMD}. Error code: ${ERROR_CODE}"
       if [ ${ERROR_CODE} -ne 0 ]; then
-        WriteFile "${LINTER}" "Failed to get version info: ${GET_VERSION_CMD}"
         fatal "[${LINTER}]: Failed to get version info: ${GET_VERSION_CMD}"
       else
         ##########################
         # Print the version info #
         ##########################
         info "Successfully found version for ${F[W]}[${LINTER}]${F[B]}: ${F[W]}${GET_VERSION_CMD}"
-        WriteFile "${LINTER}" "${GET_VERSION_CMD}"
+        WriteFile "${LINTER}" "${GET_VERSION_CMD}" "${VERSION_FILE}"
       fi
     fi
   done
-
-  #########################
-  # Print version footers #
-  #########################
-  info "---------------------------------------------"
 }
-################################################################################
-#### Function WriteFile ########################################################
+
 WriteFile() {
   ##############
   # Read Input #
   ##############
-  LINTER="$1"   # Name of the linter
-  VERSION="$2"  # Version returned from check
+  LINTER="$1"     # Name of the linter
+  VERSION="$2"    # Version returned from check
+  VERSION_FILE=$3 # Version file path
 
   #################################
   # Write the data to output file #
@@ -133,11 +88,3 @@ WriteFile() {
     fatal "Failed to write data to file!"
   fi
 }
-################################################################################
-############################### MAIN ###########################################
-################################################################################
-
-#######################
-# BuildLinterVersions #
-#######################
-BuildLinterVersions

--- a/lib/worker.sh
+++ b/lib/worker.sh
@@ -281,7 +281,7 @@ function LintCodebase() {
             # Error #
             #########
             error "Found errors in [${LINTER_NAME}] linter!"
-            error "Error code: ${ERROR_CODE}. Command run:${NC}[\$${LINT_CMD}]"
+            error "Error code: ${ERROR_CODE}. Command output:${NC}[${LINT_CMD}]"
             # Increment the error count
             (("ERRORS_FOUND_${FILE_TYPE}++"))
           fi
@@ -319,7 +319,7 @@ function LintCodebase() {
           #########
           error "Found errors in [${LINTER_NAME}] linter!"
           error "This file should have failed test case!"
-          error "Error code: ${ERROR_CODE}. Command run:${NC}[\$${LINT_CMD}]."
+          error "Error code: ${ERROR_CODE}. Command output:${NC}[${LINT_CMD}]."
           # Increment the error count
           (("ERRORS_FOUND_${FILE_TYPE}++"))
         else
@@ -337,7 +337,7 @@ function LintCodebase() {
           AddDetailedMessageIfEnabled "${LINT_CMD}" "${TMPFILE}"
         fi
       fi
-      debug "Error code: ${ERROR_CODE}. Command run:${NC}[\$${LINT_CMD}]."
+      debug "Error code: ${ERROR_CODE}. Command output:${NC}[${LINT_CMD}]."
     done
 
     #################################


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #879 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Use the already-define linter names array while building the file list. To do this, I introduced a new variable (`WRITE_LINTER_VERSIONS_FILE`). When that variable is set to `true`, `linter.sh` runs but exists immediately after building the linter versions file. I didn't document this variable in the README because it's mostly for internal use. We can use a similar approach when we want to reuse the logic in `linter.sh`.
1. Fail hard with a `fatal` if we can't find the version of a linter, instead of a `warn`. This is useful to fail fast and doesn't impact end users because this check runs only when building the image.
1. Correct command debug output text in `worker.sh`, because we `echo` the output of commands, not the commands.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
