### PR TITLE
Update bug issue template with logging instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,25 +4,45 @@ about: Create a report to help us improve
 title: ''
 labels: bug
 assignees: ''
-
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Describe the bug
 
-**To Reproduce**
-Steps to reproduce the behavior:
+<!-- A clear and concise description of what the bug is. -->
+
+## Expected behavior
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Steps to Reproduce
+
+<!-- Steps to reproduce the behavior. -->
+<!-- To speed up the triaging of your request, try to reproduce the issue running super-linter locally, -->
+<!-- pointing to a specific container image tag. -->
+<!-- Remember to set ACTIONS_RUNNER_DEBUG=true for complete output -->
+<!-- Example: -->
+<!--
+docker run \
+  -e RUN_LOCAL=true \
+  -e ACTIONS_RUNNER_DEBUG=true \
+  -e DISABLE_ERRORS=false \
+  -e ERROR_ON_MISSING_EXEC_BIT=true \
+  -e LINTER_RULES_PATH=. \
+  -e MULTI_STATUS=false \
+  -e VALIDATE_ALL_CODEBASE=true \
+  -v $(pwd):/tmp/lint \
+  ghcr.io/github/super-linter:v3.13.5
+-->
 
 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+1. Click on '....'
+1. Scroll down to '....'
+1. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+## Logs
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- Report logs an to help explain your problem. -->
 
-**Additional context**
-Add any other context about the problem here.
+## Additional context
+
+<!-- Add any other relevant information about the problem here. -->


### PR DESCRIPTION
## Proposed Changes

Now that super-linter is one of the popular choices for linting, I took a chance to update the `bug` issue template to guide users in providing more accurate reports.

Update the issue template for bugs:

1. Use headings instead of bold text for sections.
1. Add instructions about how to run super-linter locally to reproduce the issue.
1. Change the ask for screenshots to an ask for logs.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
