### PR TITLE
fix find

### DIFF
--- a/lib/buildFileList.sh
+++ b/lib/buildFileList.sh
@@ -99,7 +99,7 @@ function BuildFileList() {
     -path "*/.venv" -prune -o \
     -path "*/.rbenv" -prune -o \
     -path "*/.terragrunt-cache" -prune -o \
-    -type f 2>&1 | sort )
+    -type f 2>&1 |  grep -v -w '\.git' | sort )
   fi
 
   #######################


### PR DESCRIPTION
This closes #954 

This is a better way to help remove the `.git` folder from showing up in the list