### PR TITLE
Exclude __pycache__ and .pytest_cache from file list

### DIFF
--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -95,9 +95,11 @@ function BuildFileList() {
     debug "Populating the file list with all the files in the ${WORKSPACE_PATH} workspace"
     mapfile -t RAW_FILE_ARRAY < <(find "${WORKSPACE_PATH}" \
       -not \( -path '*/\.git' -prune \) \
+      -not \( -path '*/\.pytest_cache' -prune \) \
       -not \( -path '*/\.rbenv' -prune \) \
       -not \( -path '*/\.terragrunt-cache' -prune \) \
       -not \( -path '*/\.venv' -prune \) \
+      -not \( -path '*/\__pycache__' -prune \) \
       -type f \
       2>&1 | sort)
 


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #997 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Exclude the `__pycache__` directory from the file list. This directory [contains the compiled version of python modules](https://docs.python.org/3/tutorial/modules.html#compiled-python-files) and shouldn't be linted.
1. Exclude the `.pytest_cache` directory from the file list. This directory [contains caching for pytest tests](https://docs.pytest.org/en/latest/cache.html).

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
