### PR TITLE
Update Rubocop to 1.3.1. from 0.82.0 which is 6 months behind. 

### DIFF
--- a/dependencies/Gemfile
+++ b/dependencies/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem "rubocop", "~> 0.82.0"
+gem "rubocop", "~> 1.3.1"
 gem "rubocop-github", "~> 0.16.0"
 gem "rubocop-performance", "~>1.7.1"
 gem "rubocop-rails", "~> 2.5"


### PR DESCRIPTION

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #
Update Rubocop Gem to 1.3.1. from 0.82.0 which is 6 months behind. 
https://rubygems.org/gems/rubocop/versions


## Readiness Checklist

### Author/Contributor
- [X ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
