### PR TITLE
Manage Ruby dependency updates with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,9 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 10
 
+  # Maintain dependencies for Ruby
+  - package-ecosystem: "bundler"
+    directory: "/dependencies"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Proposed Changes

As pointed out in #1013, Ruby dependency updates are not managed by dependabot. This PR fixes this, unless there's a reason not to do that, that I'm not aware of.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
