### PR TITLE
Enable @SuppressWarnings annotation support by default for Java

### DIFF
--- a/.automation/test/java/java_bad_2.java
+++ b/.automation/test/java/java_bad_2.java
@@ -6,7 +6,7 @@ public class Application {
    * @param args
    */
   public static void main(final String[] args) {
-    System.out.println("hello");
+    SpringApplication.run(Application.class, args);
   }
 
 }

--- a/.automation/test/java/java_bad_2.java
+++ b/.automation/test/java/java_bad_2.java
@@ -1,0 +1,12 @@
+public class Application {
+
+  /**
+   * main.
+   *
+   * @param args
+   */
+  public static void main(final String[] args) {
+    System.out.println("hello");
+  }
+
+}

--- a/.automation/test/java/java_good_2.java
+++ b/.automation/test/java/java_good_2.java
@@ -7,7 +7,7 @@ public class Application {
    * @param args
    */
   public static void main(final String[] args) {
-    System.out.println("hello");
+    SpringApplication.run(Application.class, args);
   }
 
 }

--- a/.automation/test/java/java_good_2.java
+++ b/.automation/test/java/java_good_2.java
@@ -1,0 +1,13 @@
+@SuppressWarnings("checkstyle:hideutilityclassconstructor")
+public class Application {
+
+  /**
+   * main.
+   *
+   * @param args
+   */
+  public static void main(final String[] args) {
+    System.out.println("hello");
+  }
+
+}

--- a/.automation/test/java/reports/expected-JAVA.tap
+++ b/.automation/test/java/reports/expected-JAVA.tap
@@ -6,7 +6,7 @@ not ok 1 - java_bad_1.java
   ...
 not ok 2 - java_bad_2.java
   ---
-  message: age: Starting audit...\n[ERROR] /tmp/lint/.automation/test/java/java_bad_2.java 1 1  Utility classes should not have a public or default constructor. [HideUtilityClassConstructor]\nAudit done.\nCheckstyle ends with 1 errors.\n
+  message: Starting audit...\n[ERROR] /tmp/lint/.automation/test/java/java_bad_2.java 1 1  Utility classes should not have a public or default constructor. [HideUtilityClassConstructor]\nAudit done.\nCheckstyle ends with 1 errors.\n
   ...
 ok 3 - java_good_1.java
 ok 4 - java_good_2.java

--- a/.automation/test/java/reports/expected-JAVA.tap
+++ b/.automation/test/java/reports/expected-JAVA.tap
@@ -1,7 +1,12 @@
 TAP version 13
-1..2
+1..4
 not ok 1 - java_bad_1.java
   ---
   message: Starting audit...\n[ERROR] /tmp/lint/.automation/test/java/java_bad_1.java 1 1  Utility classes should not have a public or default constructor. [HideUtilityClassConstructor]\n[ERROR] /tmp/lint/.automation/test/java/java_bad_1.java 1 7  Name 'java_bad_1' must match pattern '^[A-Z][a-zA-Z0-9]*$'. [TypeName]\n[ERROR] /tmp/lint/.automation/test/java/java_bad_1.java 2 1  '{' at column 1 should be on the previous line. [LeftCurly]\n[ERROR] /tmp/lint/.automation/test/java/java_bad_1.java 4 29  Parameter args should be final. [FinalParameters]\n[ERROR] /tmp/lint/.automation/test/java/java_bad_1.java 4 40  Array brackets at illegal position. [ArrayTypeStyle]\n[ERROR] /tmp/lint/.automation/test/java/java_bad_1.java 5 5  '{' at column 5 should be on the previous line. [LeftCurly]\nAudit done.\nCheckstyle ends with 6 errors.\n
   ...
-ok 2 - java_good_1.java
+not ok 2 - java_bad_2.java
+  ---
+  message: age: Starting audit...\n[ERROR] /tmp/lint/.automation/test/java/java_bad_2.java 1 1  Utility classes should not have a public or default constructor. [HideUtilityClassConstructor]\nAudit done.\nCheckstyle ends with 1 errors.\n
+  ...
+ok 3 - java_good_1.java
+ok 4 - java_good_2.java

--- a/.github/linters/sun_checks.xml
+++ b/.github/linters/sun_checks.xml
@@ -57,7 +57,7 @@
 
   <!-- Checks that a package-info.java file exists for each package.     -->
   <!-- See https://checkstyle.org/config_javadoc.html#JavadocPackage -->
-  <module name="JavadocPackage"/>
+  <!-- <module name="JavadocPackage"/> -->
 
   <!-- Checks whether files end with a new line.                        -->
   <!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->

--- a/.github/linters/sun_checks.xml
+++ b/.github/linters/sun_checks.xml
@@ -51,14 +51,13 @@
 
   <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
   <module name="SuppressionFilter">
-    <property name="file" value="${org.checkstyle.sun.suppressionfilter.config}"
-              default="checkstyle-suppressions.xml" />
+    <property name="file" value="${org.checkstyle.sun.suppressionfilter.config}" default="checkstyle-suppressions.xml" />
     <property name="optional" value="true"/>
   </module>
 
   <!-- Checks that a package-info.java file exists for each package.     -->
   <!-- See https://checkstyle.org/config_javadoc.html#JavadocPackage -->
-  <!-- <module name="JavadocPackage"/> -->
+  <module name="JavadocPackage"/>
 
   <!-- Checks whether files end with a new line.                        -->
   <!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
@@ -95,6 +94,8 @@
   <!--   <property name="fileExtensions" value="java"/> -->
   <!-- </module> -->
 
+  <!-- Enables @SuppressWarnings Support                -->
+  <module name="SuppressWarningsFilter"/>
   <module name="TreeWalker">
 
     <!-- Checks for Javadoc comments.                     -->
@@ -105,6 +106,8 @@
     <module name="JavadocVariable"/>
     <module name="JavadocStyle"/>
     <module name="MissingJavadocMethod"/>
+    <!-- Enables @SuppressWarnings Support                -->
+    <module name="SuppressWarningsHolder"/>
 
     <!-- Checks for Naming Conventions.                  -->
     <!-- See https://checkstyle.org/config_naming.html -->
@@ -121,7 +124,8 @@
     <!-- Checks for imports                              -->
     <!-- See https://checkstyle.org/config_imports.html -->
     <module name="AvoidStarImport"/>
-    <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+    <module name="IllegalImport"/>
+    <!-- defaults to sun.* packages -->
     <module name="RedundantImport"/>
     <module name="UnusedImports">
       <property name="processJavadoc" value="false"/>
@@ -188,8 +192,7 @@
 
     <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
     <module name="SuppressionXpathFilter">
-      <property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}"
-                default="checkstyle-xpath-suppressions.xml" />
+      <property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}" default="checkstyle-xpath-suppressions.xml" />
       <property name="optional" value="true"/>
     </module>
 

--- a/TEMPLATES/sun_checks.xml
+++ b/TEMPLATES/sun_checks.xml
@@ -51,8 +51,7 @@
 
   <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
   <module name="SuppressionFilter">
-    <property name="file" value="${org.checkstyle.sun.suppressionfilter.config}"
-              default="checkstyle-suppressions.xml" />
+    <property name="file" value="${org.checkstyle.sun.suppressionfilter.config}" default="checkstyle-suppressions.xml" />
     <property name="optional" value="true"/>
   </module>
 
@@ -95,6 +94,8 @@
   <!--   <property name="fileExtensions" value="java"/> -->
   <!-- </module> -->
 
+  <!-- Enables @SuppressWarnings Support                -->
+  <module name="SuppressWarningsFilter"/>
   <module name="TreeWalker">
 
     <!-- Checks for Javadoc comments.                     -->
@@ -105,6 +106,8 @@
     <module name="JavadocVariable"/>
     <module name="JavadocStyle"/>
     <module name="MissingJavadocMethod"/>
+    <!-- Enables @SuppressWarnings Support                -->
+    <module name="SuppressWarningsHolder"/>
 
     <!-- Checks for Naming Conventions.                  -->
     <!-- See https://checkstyle.org/config_naming.html -->
@@ -121,7 +124,8 @@
     <!-- Checks for imports                              -->
     <!-- See https://checkstyle.org/config_imports.html -->
     <module name="AvoidStarImport"/>
-    <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+    <module name="IllegalImport"/>
+    <!-- defaults to sun.* packages -->
     <module name="RedundantImport"/>
     <module name="UnusedImports">
       <property name="processJavadoc" value="false"/>
@@ -188,8 +192,7 @@
 
     <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
     <module name="SuppressionXpathFilter">
-      <property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}"
-                default="checkstyle-xpath-suppressions.xml" />
+      <property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}" default="checkstyle-xpath-suppressions.xml" />
       <property name="optional" value="true"/>
     </module>
 


### PR DESCRIPTION
## Proposed Changes

1. Add a Filter and a Holder into the sun_checks.xml template to support @SuppressWarnings by default. This is triggered by a use-case of Spring Boot's default Application class failing lint because it only has a static main method. 

## Readiness Checklist

### Author/Contributor
- [ x ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
