### PR TITLE
Fix rakudo promote to alpine edge community repo and update phive dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,19 +38,19 @@ ARG BUILD_VERSION
 # Label the instance and set maintainer #
 #########################################
 LABEL com.github.actions.name="GitHub Super-Linter" \
-      com.github.actions.description="Lint your code base with GitHub Actions" \
-      com.github.actions.icon="code" \
-      com.github.actions.color="red" \
-      maintainer="GitHub DevOps <github_devops@github.com>" \
-      org.opencontainers.image.created=$BUILD_DATE \
-      org.opencontainers.image.revision=$BUILD_REVISION \
-      org.opencontainers.image.version=$BUILD_VERSION \
-      org.opencontainers.image.authors="GitHub DevOps <github_devops@github.com>" \
-      org.opencontainers.image.url="https://github.com/github/super-linter" \
-      org.opencontainers.image.source="https://github.com/github/super-linter" \
-      org.opencontainers.image.documentation="https://github.com/github/super-linter" \
-      org.opencontainers.image.vendor="GitHub" \
-      org.opencontainers.image.description="Lint your code base with GitHub Actions"
+    com.github.actions.description="Lint your code base with GitHub Actions" \
+    com.github.actions.icon="code" \
+    com.github.actions.color="red" \
+    maintainer="GitHub DevOps <github_devops@github.com>" \
+    org.opencontainers.image.created=$BUILD_DATE \
+    org.opencontainers.image.revision=$BUILD_REVISION \
+    org.opencontainers.image.version=$BUILD_VERSION \
+    org.opencontainers.image.authors="GitHub DevOps <github_devops@github.com>" \
+    org.opencontainers.image.url="https://github.com/github/super-linter" \
+    org.opencontainers.image.source="https://github.com/github/super-linter" \
+    org.opencontainers.image.documentation="https://github.com/github/super-linter" \
+    org.opencontainers.image.vendor="GitHub" \
+    org.opencontainers.image.description="Lint your code base with GitHub Actions"
 
 #################################################
 # Set ENV values used for debugging the version #
@@ -276,7 +276,7 @@ RUN printf '#!/bin/bash \n\nif [[ -x "$1" ]]; then exit 0; else echo "Error: Fil
 # Install Raku and additional Edge dependencies #
 #################################################
 # Basic setup, programs and init
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories \
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repositories \
     && apk add --no-cache rakudo zef
 
 ######################

--- a/dependencies/phive.xml
+++ b/dependencies/phive.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
   <!-- When adding new linter, do not forget to add its GPG key ID to Dockerfile -->
-  <phar name="phpcs" version="^3.5" installed="3.5.5" location="/usr/local/bin/phpcs" copy="true"/>
-  <phar name="phpstan" version="^0.12" installed="0.12.34" location="/usr/local/bin/phpstan" copy="true"/>
-  <phar name="psalm" version="^3.12" installed="3.12.2" location="/usr/local/bin/psalm" copy="true"/>
+  <phar name="phpcs" version="^3.5" installed="3.5.8" location="/usr/local/bin/phpcs" copy="true"/>
+  <phar name="phpstan" version="^0.12" installed="0.12.64" location="/usr/local/bin/phpstan" copy="true"/>
+  <phar name="psalm" version="^3.12" installed="3.18.2" location="./usr/local/bin/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes builds

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Rakudo is now installed from the edge/community repo. It was promoted from edge/testing
2. Update phive dependencies, dependabot don't manage them, we need to keep this in mind and update them ocationally.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
