### PR TITLE
Bump borkdude/clj-kondo from 2020.09.09 to 2020.12.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #########################################
 # Get dependency images as build stages #
 #########################################
-FROM borkdude/clj-kondo:2020.09.09 as clj-kondo
+FROM borkdude/clj-kondo:2020.12.12 as clj-kondo
 FROM dotenvlinter/dotenv-linter:2.2.1 as dotenv-linter
 FROM mstruebing/editorconfig-checker:2.2.0 as editorconfig-checker
 FROM golangci/golangci-lint:v1.33.0 as golangci-lint


### PR DESCRIPTION
Bumps borkdude/clj-kondo from 2020.09.09 to 2020.12.12.

Signed-off-by: dependabot[bot] <support@github.com>