### PR TITLE
Tweak TFLint default config

### DIFF
--- a/TEMPLATES/.tflint.hcl
+++ b/TEMPLATES/.tflint.hcl
@@ -1,31 +1,6 @@
-// https://github.com/terraform-linters/tflint/blob/master/docs/guides/config.md
+// https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/config.md
 config {
   module = false
   force = false
-
-  // aws_credentials = {
-  //   access_key = "AWS_ACCESS_KEY"
-  //   secret_key = "AWS_SECRET_KEY"
-  //   region     = "us-east-1"
-  // }
-
-  // ignore_module = {
-  //   "github.com/terraform-linters/example-module" = true
-  // }
-
-  // varfile = ["example1.tfvars", "example2.tfvars"]
-
-  // variables = ["foo=bar", "bar=[\"baz\"]"]
 }
 
-rule "aws_instance_invalid_type" {
-  enabled = false
-}
-
-rule "aws_instance_previous_type" {
-  enabled = false
-}
-
-// plugin "example" {
-//   enabled = true
-// }


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

AWS rules are now optional in TFLint v0.23.0, so remove the relevant rule config.
See https://github.com/terraform-linters/tflint/releases/tag/v0.23.0

Currently, the `.tflint.hcl` means the same behavior as the default, so maybe you can remove the file.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
