### PR TITLE
Move switch back to code branch

### DIFF
--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -161,6 +161,27 @@ function BuildFileList() {
     warn "No files were found in the GITHUB_WORKSPACE:[${GITHUB_WORKSPACE}] to lint!"
   fi
 
+  if [ "${VALIDATE_ALL_CODEBASE}" == "false" ]; then
+    #########################################
+    # Need to switch back to branch of code #
+    #########################################
+    SWITCH2_CMD=$(git -C "${GITHUB_WORKSPACE}" checkout --progress --force "${GITHUB_SHA}" 2>&1)
+
+    #######################
+    # Load the error code #
+    #######################
+    ERROR_CODE=$?
+
+    ##############################
+    # Check the shell for errors #
+    ##############################
+    if [ ${ERROR_CODE} -ne 0 ]; then
+      # Error
+      error "Failed to switch back to branch!"
+      fatal "[${SWITCH2_CMD}]"
+    fi
+  fi
+
   ################################################
   # Iterate through the array of all files found #
   ################################################
@@ -183,7 +204,7 @@ function BuildFileList() {
     ##########################################################
     if [ ! -f "${FILE}" ]; then
       # File not found in workspace
-      debug "File:{$FILE} existed in commit data, but not found on file system, skipping..."
+      warn "File:{$FILE} existed in commit data, but not found on file system, skipping..."
       continue
     fi
 
@@ -668,27 +689,6 @@ function BuildFileList() {
     ##########################################
     debug ""
   done
-
-  if [ "${VALIDATE_ALL_CODEBASE}" == "false" ]; then
-    #########################################
-    # Need to switch back to branch of code #
-    #########################################
-    SWITCH2_CMD=$(git -C "${GITHUB_WORKSPACE}" checkout --progress --force "${GITHUB_SHA}" 2>&1)
-
-    #######################
-    # Load the error code #
-    #######################
-    ERROR_CODE=$?
-
-    ##############################
-    # Check the shell for errors #
-    ##############################
-    if [ ${ERROR_CODE} -ne 0 ]; then
-      # Error
-      error "Failed to switch back to branch!"
-      fatal "[${SWITCH2_CMD}]"
-    fi
-  fi
 
   ################
   # Footer print #


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes a bug, where we checked the file existence before switching back to the branch of code (we switch to default branch previously, to pull.) so new files where been checked properly on the PRs

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Move the switch back to the branch of code, before addif each file to the proper array
2. Change verbose level to warn, of message indicating that a files is on the commit but not on the file system. This is a warn because it alerts that something is odd, if the commit data has a file that is not in the file system something may be wrong.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
