### PR TITLE
Tool path specified for dotnet tool installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,7 @@ RUN wget --tries=5 -O dotnet-install.sh https://dot.net/v1/dotnet-install.sh \
     && ./dotnet-install.sh --install-dir /usr/share/dotnet -channel Current -version latest \
     && /usr/share/dotnet/dotnet tool install --tool-path /var/cache/dotnet dotnet-format
 
-ENV PATH="${PATH}:/car/cache/dotnet/.dotnet/tools:/usr/share/dotnet"
+ENV PATH="${PATH}:/var/cache/dotnet/.dotnet/tools:/usr/share/dotnet"
 
 ##############################
 # Installs Perl dependencies #

--- a/Dockerfile
+++ b/Dockerfile
@@ -147,9 +147,9 @@ RUN bundle install
 RUN wget --tries=5 -O dotnet-install.sh https://dot.net/v1/dotnet-install.sh \
     && chmod +x dotnet-install.sh \
     && ./dotnet-install.sh --install-dir /usr/share/dotnet -channel Current -version latest \
-    && /usr/share/dotnet/dotnet tool install --tool-path /var/cache/dotnet dotnet-format
+    && /usr/share/dotnet/dotnet tool install --tool-path /var/cache/dotnet/tools dotnet-format
 
-ENV PATH="${PATH}:/var/cache/dotnet/.dotnet/tools:/usr/share/dotnet"
+ENV PATH="${PATH}:/var/cache/dotnet/tools:/usr/share/dotnet"
 
 ##############################
 # Installs Perl dependencies #

--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ RUN bundle install
 RUN wget --tries=5 -O dotnet-install.sh https://dot.net/v1/dotnet-install.sh \
     && chmod +x dotnet-install.sh \
     && ./dotnet-install.sh --install-dir /usr/share/dotnet -channel Current -version latest \
-    && /usr/share/dotnet/dotnet tool install -g --tool-path /var/cache/dotnet dotnet-format
+    && /usr/share/dotnet/dotnet tool install --tool-path /var/cache/dotnet dotnet-format
 
 ENV PATH="${PATH}:/root/.dotnet/tools:/usr/share/dotnet"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,7 @@ RUN wget --tries=5 -O dotnet-install.sh https://dot.net/v1/dotnet-install.sh \
     && ./dotnet-install.sh --install-dir /usr/share/dotnet -channel Current -version latest \
     && /usr/share/dotnet/dotnet tool install --tool-path /var/cache/dotnet dotnet-format
 
-ENV PATH="${PATH}:/root/.dotnet/tools:/usr/share/dotnet"
+ENV PATH="${PATH}:/car/cache/dotnet/.dotnet/tools:/usr/share/dotnet"
 
 ##############################
 # Installs Perl dependencies #

--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ RUN bundle install
 RUN wget --tries=5 -O dotnet-install.sh https://dot.net/v1/dotnet-install.sh \
     && chmod +x dotnet-install.sh \
     && ./dotnet-install.sh --install-dir /usr/share/dotnet -channel Current -version latest \
-    && /usr/share/dotnet/dotnet tool install -g dotnet-format
+    && /usr/share/dotnet/dotnet tool install -g --tool-path /var/cache/dotnet dotnet-format
 
 ENV PATH="${PATH}:/root/.dotnet/tools:/usr/share/dotnet"
 


### PR DESCRIPTION
A tool path is specified to prevent installation of dotnet tools into /root/.dotnet/. Instead dotnet tools are installed into /var/cache/dotnet. This allows all users to access installed dotnet tools. Especially useful in unprivileged container runtimes.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #1153

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. As per documentation [dotnet tool install](https://docs.microsoft.com/de-de/dotnet/core/tools/dotnet-tool-install) the `--tool-path` option is added. See description.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
