### PR TITLE
fix, checkout DEFAULT_BRANCH for diff base

### DIFF
--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -68,6 +68,34 @@ function BuildFileList() {
     # Need to build a list of all files changed
     # This can be pulled from the GITHUB_EVENT_PATH payload
 
+    ################
+    # print header #
+    ################
+    debug "----------------------------------------------"
+    debug "Pulling in code history and branches..."
+
+    #################################################################################
+    # Switch codebase back to the default branch to get a list of all files changed #
+    #################################################################################
+    SWITCH_CMD=$(
+      git -C "${GITHUB_WORKSPACE}" pull --quiet
+      git -C "${GITHUB_WORKSPACE}" checkout "${DEFAULT_BRANCH}" 2>&1
+    )
+
+    #######################
+    # Load the error code #
+    #######################
+    ERROR_CODE=$?
+
+    ##############################
+    # Check the shell for errors #
+    ##############################
+    if [ ${ERROR_CODE} -ne 0 ]; then
+      # Error
+      info "Failed to switch to ${DEFAULT_BRANCH} branch to get files changed!"
+      fatal "[${SWITCH_CMD}]"
+    fi
+
     if [ "${GITHUB_EVENT_NAME}" == "push" ]; then
       ################
       # push event   #


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1.  revert some breaking changes, #1305 

`actions/checkout@v2` with full history will execute commands like below.  (you can reproduce using these commands)

```
$ git init
$ git remote add origin git@github.com:HatsuneMiku3939/super-linter-pr1305-test.git
$ git -c protocol.version=2 fetch --prune --progress --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* +1100f8be9fbb1b5c55ee885bf7cbc5b7a1127ef7:refs/remotes//pull/1/merge
$ git checkout --progress --force refs/remotes/pull/1/merge
Note: switching to 'refs/remotes/pull/1/merge'.
...

HEAD is now at 1100f8b Merge 8316d3f11811c685b68e454b0052defdb1c8aba0 into 598eae3cae14d3aede225035dca210a7c89b732b
```

at this time, we have a no `DEFAULT_BRANCH` in local history.

```
$ git branch
* (HEAD detached at pull/1/merge)
```

as a result, `GenerateFileDiff` always fails. 

```
$ git diff --name-only master...8316d3f11811c685b68e454b0052defdb1c8aba0 --diff-filter=d
fatal: ambiguous argument 'master...8316d3f11811c685b68e454b0052defdb1c8aba0': unknown revision or path not in the working tree.
```

I think switch back to default branch is mandatory.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
