### PR TITLE
Fix to lint other .env.* files

### DIFF
--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -341,7 +341,7 @@ function BuildFileList() {
     #####################
     # Get the ENV files #
     #####################
-    elif [ "${FILE_TYPE}" == "env" ]; then
+    elif [ "${FILE_TYPE}" == "env" ] || [[ "${BASE_FILE}" == *".env."* ]]; then
       ################################
       # Append the file to the array #
       ################################


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Fix to run dotenv linter on any .env.* file, like .env.example

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
