### PR TITLE
fix: Install git in final docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -330,14 +330,15 @@ ENV BUILD_REVISION=$BUILD_REVISION
 ENV BUILD_VERSION=$BUILD_VERSION
 ENV ARM_TTK_PSD1="${ARM_TTK_DIRECTORY}/arm-ttk-master/arm-ttk/arm-ttk.psd1"
 
-##############################
-# Install Phive dependencies #
-##############################
+######################################
+# Install Phive dependencies and git #
+######################################
 RUN wget --tries=5 -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
     && wget --tries=5 -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
     && apk add --no-cache \
     bash \
     ca-certificates \
+    git git-lfs \
     glibc-${GLIBC_VERSION}.apk \
     gnupg \
     php7 php7-phar php7-json php7-mbstring php-xmlwriter \


### PR DESCRIPTION
This is missing since the v3.16.0 release when refactoring the Dockerfile.

Fixes: https://github.com/github/super-linter/issues/1482

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

https://github.com/github/super-linter/issues/1482

## Proposed Changes

1. Install `git` and `git-lfs` in final docker image


## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
