### PR TITLE
Allow ansible-lint with git diffs

### DIFF
--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -100,7 +100,7 @@ function BuildFileList() {
       ################
       # push event   #
       ################
-      DIFF_TREE_CMD="git -C ${GITHUB_WORKSPACE} diff-tree --no-commit-id --name-only -r ${GITHUB_SHA} | xargs -I % sh -c "echo ${GITHUB_WORKSPACE}/%" 2>&1"
+      DIFF_TREE_CMD="git -C ${GITHUB_WORKSPACE} diff-tree --no-commit-id --name-only -r ${GITHUB_SHA} | xargs -I % sh -c 'echo \"${GITHUB_WORKSPACE}/%\"' 2>&1"
       GenerateFileDiff "$DIFF_TREE_CMD"
 
       ###############################################################
@@ -114,7 +114,7 @@ function BuildFileList() {
         debug "----------------------------------------------"
         debug "WARN: Generation of File array with diff-tree produced [0] items, trying with git diff..."
 
-        DIFF_CMD="git -C ${GITHUB_WORKSPACE} diff --name-only ${DEFAULT_BRANCH}...${GITHUB_SHA} --diff-filter=d | xargs -I % sh -c "echo ${GITHUB_WORKSPACE}/%" 2>&1"
+        DIFF_CMD="git -C ${GITHUB_WORKSPACE} diff --name-only ${DEFAULT_BRANCH}...${GITHUB_SHA} --diff-filter=d | xargs -I % sh -c 'echo \"${GITHUB_WORKSPACE}/%\"' 2>&1"
         GenerateFileDiff "$DIFF_CMD"
 
       fi
@@ -122,7 +122,7 @@ function BuildFileList() {
       ################
       # PR event     #
       ################
-      DIFF_CMD="git -C ${GITHUB_WORKSPACE} diff --name-only ${DEFAULT_BRANCH}...${GITHUB_SHA} --diff-filter=d | xargs -I % sh -c "echo ${GITHUB_WORKSPACE}/%" 2>&1"
+      DIFF_CMD="git -C ${GITHUB_WORKSPACE} diff --name-only ${DEFAULT_BRANCH}...${GITHUB_SHA} --diff-filter=d | xargs -I % sh -c 'echo \"${GITHUB_WORKSPACE}/%\"' 2>&1"
       GenerateFileDiff "$DIFF_CMD"
     fi
   else

--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -20,7 +20,7 @@ function GenerateFileDiff() {
   #################################################
   # Get the Array of files changed in the commits #
   #################################################
-  CMD_OUTPUT=$(eval $CMD)
+  CMD_OUTPUT=$(eval "$CMD")
 
   #######################
   # Load the error code #

--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -20,7 +20,7 @@ function GenerateFileDiff() {
   #################################################
   # Get the Array of files changed in the commits #
   #################################################
-  CMD_OUTPUT=$($CMD)
+  CMD_OUTPUT=$(eval $CMD)
 
   #######################
   # Load the error code #

--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -100,7 +100,7 @@ function BuildFileList() {
       ################
       # push event   #
       ################
-      DIFF_TREE_CMD="git -C ${GITHUB_WORKSPACE} diff-tree --no-commit-id --name-only -r ${GITHUB_SHA}"
+      DIFF_TREE_CMD="git -C ${GITHUB_WORKSPACE} diff-tree --no-commit-id --name-only -r ${GITHUB_SHA} | xargs -I % sh -c "echo ${GITHUB_WORKSPACE}/%" 2>&1"
       GenerateFileDiff "$DIFF_TREE_CMD"
 
       ###############################################################
@@ -114,7 +114,7 @@ function BuildFileList() {
         debug "----------------------------------------------"
         debug "WARN: Generation of File array with diff-tree produced [0] items, trying with git diff..."
 
-        DIFF_CMD="git -C ${GITHUB_WORKSPACE} diff --name-only ${DEFAULT_BRANCH}...${GITHUB_SHA} --diff-filter=d"
+        DIFF_CMD="git -C ${GITHUB_WORKSPACE} diff --name-only ${DEFAULT_BRANCH}...${GITHUB_SHA} --diff-filter=d | xargs -I % sh -c "echo ${GITHUB_WORKSPACE}/%" 2>&1"
         GenerateFileDiff "$DIFF_CMD"
 
       fi
@@ -122,7 +122,7 @@ function BuildFileList() {
       ################
       # PR event     #
       ################
-      DIFF_CMD="git -C ${GITHUB_WORKSPACE} diff --name-only ${DEFAULT_BRANCH}...${GITHUB_SHA} --diff-filter=d"
+      DIFF_CMD="git -C ${GITHUB_WORKSPACE} diff --name-only ${DEFAULT_BRANCH}...${GITHUB_SHA} --diff-filter=d | xargs -I % sh -c "echo ${GITHUB_WORKSPACE}/%" 2>&1"
       GenerateFileDiff "$DIFF_CMD"
     fi
   else


### PR DESCRIPTION
super-linter checks the path of the file in lib/functions/detectFiles.sh to determine whether the file is an ansible playbook. 

When VALIDATE_ALL_CODEBASE=true, a list of absolute paths is generated which matches the expected path.
When VALIDATE_ALL_CODEBASE=false, a list of relative paths is generated so no files are "detected" as ansible playbooks. 

This change outputs everything as an absolute path so diffs will also work.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
