### PR TITLE
Image 4.0

### DIFF
--- a/.automation/validate-docker-labels.sh
+++ b/.automation/validate-docker-labels.sh
@@ -10,6 +10,7 @@
 # GITHUB_WORKSPACE="${GITHUB_WORKSPACE}" # GitHub Workspace
 # GITHUB_SHA="${GITHUB_SHA}"   # Sha used to create this branch
 # BUILD_DATE="${BUILD_DATE}"   # Date the container was built
+IMAGE="${1}"                                                                         # Image of the super-linter we build
 BUILD_REVISION="${GITHUB_SHA}"                                                       # GitHub Sha
 BUILD_VERSION="${GITHUB_SHA}"                                                        # Version of the container
 ORG_REPO="github/super-linter"                                                       # Org/repo
@@ -46,7 +47,12 @@ ValidateLabel() {
   ########################
   # Get the docker label #
   ########################
-  LABEL=$(docker inspect --format "{{ index .Config.Labels \"${CONTAINER_KEY}\" }}" "${REGISTRY}/${ORG_REPO}:${GITHUB_SHA}")
+  LABEL=''
+  if [[ "${IMAGE}" == "slim" ]]; then
+    LABEL=$(docker inspect --format "{{ index .Config.Labels \"${CONTAINER_KEY}\" }}" "${REGISTRY}/${ORG_REPO}:slim-${GITHUB_SHA}")
+  else
+    LABEL=$(docker inspect --format "{{ index .Config.Labels \"${CONTAINER_KEY}\" }}" "${REGISTRY}/${ORG_REPO}:${GITHUB_SHA}")
+  fi
 
   ###################
   # Check the value #

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 ######################################################################
 # These owners will be the default owners for everything in the repo #
 ######################################################################
-*       @admiralawkbar @jwiebalk @zkoppert @IAmHughes @nemchik @Hanse00 @github-actions @GaboFDC @ferrarimarco
+*       @admiralawkbar @jwiebalk @zkoppert @nemchik @Hanse00 @github-actions @GaboFDC @ferrarimarco

--- a/.github/workflows/deploy-DEV-slim.yml
+++ b/.github/workflows/deploy-DEV-slim.yml
@@ -75,7 +75,7 @@ jobs:
       ########################################
       - name: Run Docker label test cases
         shell: bash
-        run: .automation/validate-docker-labels.sh
+        run: .automation/validate-docker-labels.sh "slim"
 
       ########################################
       # Edit action.yml for test local build #
@@ -120,7 +120,7 @@ jobs:
       - name: Run the test suite
         shell: bash
         run: |
-          make test
+          make IMAGE=slim test
 
       ##########################
       # Codacy Coverage Report #

--- a/.github/workflows/deploy-DEV-slim.yml
+++ b/.github/workflows/deploy-DEV-slim.yml
@@ -92,18 +92,18 @@ jobs:
         run: |
           make info
 
-      ##########################
-      # Test in action context #
-      ##########################
-      # Test the built image in the actions context.
-      # Not the container directly, and not using RUN_LOCAL=true
-      - name: Test the local action
-        uses: ./
-        env:
-          ACTIONS_RUNNER_DEBUG: true
-          ERROR_ON_MISSING_EXEC_BIT: true
-          VALIDATE_ALL_CODEBASE: false
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # ##########################
+      # # Test in action context #
+      # ##########################
+      # # Test the built image in the actions context.
+      # # Not the container directly, and not using RUN_LOCAL=true
+      # - name: Test the local action
+      #   uses: ./
+      #   env:
+      #     ACTIONS_RUNNER_DEBUG: true
+      #     ERROR_ON_MISSING_EXEC_BIT: true
+      #     VALIDATE_ALL_CODEBASE: false
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       ###############################################################
       # Fix file and dir ownership.                                 #

--- a/.github/workflows/deploy-DEV-slim.yml
+++ b/.github/workflows/deploy-DEV-slim.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   build:
     # Name the Job
-    name: Deploy Docker Image - DEV
+    name: Deploy Docker Image - DEV - SLIM
     # Set the agent to run on
     runs-on: ubuntu-latest
     # Prevent duplicate run from happening when a forked push is committed
@@ -61,26 +61,14 @@ jobs:
       ##########################################
       # Build and Push containers to registries #
       ###########################################
-      - name: Build Docker slim image
+      - name: Build Docker image - SLIM
         run: |
           docker build \
           --build-arg BUILD_DATE=${{ env.BUILD_DATE }} \
           --build-arg BUILD_REVISION=${{ github.sha }} \
           --build-arg BUILD_VERSION=${{ github.sha }} \
-          -t ghcr.io/github/super-linter:${{ github.sha }}-slim \
-          -t ghcr.io/github/super-linter:test-slim -f Dockerfile-slim .
-
-      ###########################################
-      # Build and Push containers to registries #
-      ###########################################
-      - name: Build Docker standard image
-        run: |
-          docker build \
-          --build-arg BUILD_DATE=${{ env.BUILD_DATE }} \
-          --build-arg BUILD_REVISION=${{ github.sha }} \
-          --build-arg BUILD_VERSION=${{ github.sha }} \
-          -t ghcr.io/github/super-linter:${{ github.sha }} \
-          -t ghcr.io/github/super-linter:test -f Dockerfile .
+          -t ghcr.io/github/super-linter:slim-${{ github.sha }} \
+          -t ghcr.io/github/super-linter:slim-test -f Dockerfile-slim .
 
       ########################################
       # Validates the metadata docker labels #
@@ -149,7 +137,7 @@ jobs:
       #####################################
       # Run Linter against Test code base #
       #####################################
-      - name: Run Test Cases - standard
+      - name: Run Test Cases - SLIM
         shell: bash
         run: |
           docker run \
@@ -159,22 +147,7 @@ jobs:
           -e ACTIONS_RUNNER_DEBUG=true \
           -e ERROR_ON_MISSING_EXEC_BIT=true \
           -v ${GITHUB_WORKSPACE}:/tmp/lint \
-          ghcr.io/github/super-linter:${GITHUB_SHA}
-
-      #####################################
-      # Run Linter against Test code base #
-      #####################################
-      - name: Run Test Cases - slim
-        shell: bash
-        run: |
-          docker run \
-          -e RUN_LOCAL=true \
-          -e TEST_CASE_RUN=true \
-          -e ANSIBLE_DIRECTORY=.automation/test/ansible \
-          -e ACTIONS_RUNNER_DEBUG=true \
-          -e ERROR_ON_MISSING_EXEC_BIT=true \
-          -v ${GITHUB_WORKSPACE}:/tmp/lint \
-          ghcr.io/github/super-linter:${GITHUB_SHA}-slim
+          ghcr.io/github/super-linter:slim-${GITHUB_SHA}
 
       #########################################
       # Clean code base to run against it all #
@@ -186,7 +159,7 @@ jobs:
       ############################################
       # Run Linter against ALL cleaned code base #
       ############################################
-      - name: Run against all code base
+      - name: Run against all code base - SLIM
         shell: bash
         run: |
           docker run \
@@ -195,18 +168,4 @@ jobs:
           -e ACTIONS_RUNNER_DEBUG=true \
           -e ERROR_ON_MISSING_EXEC_BIT=true \
           -v ${GITHUB_WORKSPACE}:/tmp/lint \
-          ghcr.io/github/super-linter:${GITHUB_SHA}
-
-      ############################################
-      # Run Linter against ALL cleaned code base #
-      ############################################
-      - name: Run against all code base - slim
-        shell: bash
-        run: |
-          docker run \
-          -e RUN_LOCAL=true \
-          -e OUTPUT_DETAILS=detailed \
-          -e ACTIONS_RUNNER_DEBUG=true \
-          -e ERROR_ON_MISSING_EXEC_BIT=true \
-          -v ${GITHUB_WORKSPACE}:/tmp/lint \
-          ghcr.io/github/super-linter:${GITHUB_SHA}-slim
+          ghcr.io/github/super-linter:slim-${GITHUB_SHA}

--- a/.github/workflows/deploy-DEV-slim.yml
+++ b/.github/workflows/deploy-DEV-slim.yml
@@ -82,7 +82,7 @@ jobs:
       ########################################
       - name: Edit an action.yml file for test local build
         run: |
-          sed -i "s/super-linter:.*/super-linter:${GITHUB_SHA}'/g" action.yml
+          sed -i "s/super-linter:.*/super-linter:slim-${GITHUB_SHA}'/g" action.yml
 
       ######################
       # Gather information #
@@ -92,18 +92,18 @@ jobs:
         run: |
           make info
 
-      # ##########################
-      # # Test in action context #
-      # ##########################
-      # # Test the built image in the actions context.
-      # # Not the container directly, and not using RUN_LOCAL=true
-      # - name: Test the local action
-      #   uses: ./
-      #   env:
-      #     ACTIONS_RUNNER_DEBUG: true
-      #     ERROR_ON_MISSING_EXEC_BIT: true
-      #     VALIDATE_ALL_CODEBASE: false
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ##########################
+      # Test in action context #
+      ##########################
+      # Test the built image in the actions context.
+      # Not the container directly, and not using RUN_LOCAL=true
+      - name: Test the local action
+        uses: ./
+        env:
+          ACTIONS_RUNNER_DEBUG: true
+          ERROR_ON_MISSING_EXEC_BIT: true
+          VALIDATE_ALL_CODEBASE: false
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       ###############################################################
       # Fix file and dir ownership.                                 #

--- a/.github/workflows/deploy-DEV-standard.yml
+++ b/.github/workflows/deploy-DEV-standard.yml
@@ -1,0 +1,170 @@
+---
+#########################
+#########################
+## Deploy Docker Image ##
+#########################
+#########################
+
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+
+#######################################
+# Start the job on all push to master #
+#######################################
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+    branches-ignore: [master]
+  pull_request:
+    branches-ignore: [ ]
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    # Name the Job
+    name: Deploy Docker Image - DEV
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+    # Prevent duplicate run from happening when a forked push is committed
+    if: github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v2.3.4
+        with:
+          # Full git history is needed to get a proper list
+          # of changed files within `super-linter`
+          fetch-depth: 0
+
+      ########################
+      # Get the current date #
+      ########################
+      - name: Get current date
+        run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> ${GITHUB_ENV}
+
+      ###################################
+      # Build image locally for testing #
+      ###################################
+      ###########################################
+      # Build and Push containers to registries #
+      ###########################################
+      - name: Build Docker standard image
+        run: |
+          docker build \
+          --build-arg BUILD_DATE=${{ env.BUILD_DATE }} \
+          --build-arg BUILD_REVISION=${{ github.sha }} \
+          --build-arg BUILD_VERSION=${{ github.sha }} \
+          -t ghcr.io/github/super-linter:${{ github.sha }} \
+          -t ghcr.io/github/super-linter:test -f Dockerfile .
+
+      ########################################
+      # Validates the metadata docker labels #
+      ########################################
+      - name: Run Docker label test cases
+        shell: bash
+        run: .automation/validate-docker-labels.sh
+
+      ########################################
+      # Edit action.yml for test local build #
+      ########################################
+      - name: Edit an action.yml file for test local build
+        run: |
+          sed -i "s/super-linter:.*/super-linter:${GITHUB_SHA}'/g" action.yml
+
+      ######################
+      # Gather information #
+      ######################
+      - name: Gather information about the runtime environment
+        shell: bash
+        run: |
+          make info
+
+      ##########################
+      # Test in action context #
+      ##########################
+      # Test the built image in the actions context.
+      # Not the container directly, and not using RUN_LOCAL=true
+      - name: Test the local action
+        uses: ./
+        env:
+          ACTIONS_RUNNER_DEBUG: true
+          ERROR_ON_MISSING_EXEC_BIT: true
+          VALIDATE_ALL_CODEBASE: false
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      ###############################################################
+      # Fix file and dir ownership.                                 #
+      # Workaround for https://github.com/actions/runner/issues/434 #
+      ###############################################################
+      - name: Fix file and directory ownership
+        shell: bash
+        run: |
+          sudo chown -R "$(id -u)":"$(id -g)" "$(pwd)"
+
+      ##################
+      # Run test cases #
+      ##################
+      - name: Run the test suite
+        shell: bash
+        run: |
+          make test
+
+      ##########################
+      # Codacy Coverage Report #
+      ##########################
+      - name: Upload the code coverage report
+        uses: codacy/codacy-coverage-reporter-action@1.0.1
+        # Dependabot does not have priv to see the secret, so will
+        # fail opn bump jobs...
+        continue-on-error: true
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: test/reports/cobertura/runTests.sh/cobertura.xml
+
+      #####################################
+      # Run Linter against Test code base #
+      #####################################
+      - name: Run Test Cases - standard
+        shell: bash
+        run: |
+          docker run \
+          -e RUN_LOCAL=true \
+          -e TEST_CASE_RUN=true \
+          -e ANSIBLE_DIRECTORY=.automation/test/ansible \
+          -e ACTIONS_RUNNER_DEBUG=true \
+          -e ERROR_ON_MISSING_EXEC_BIT=true \
+          -v ${GITHUB_WORKSPACE}:/tmp/lint \
+          ghcr.io/github/super-linter:${GITHUB_SHA}
+
+      #########################################
+      # Clean code base to run against it all #
+      #########################################
+      - name: Clean Test code base for additional testing
+        shell: bash
+        run: .automation/clean-code-base-for-tests.sh
+
+      ############################################
+      # Run Linter against ALL cleaned code base #
+      ############################################
+      - name: Run against all code base
+        shell: bash
+        run: |
+          docker run \
+          -e RUN_LOCAL=true \
+          -e OUTPUT_DETAILS=detailed \
+          -e ACTIONS_RUNNER_DEBUG=true \
+          -e ERROR_ON_MISSING_EXEC_BIT=true \
+          -v ${GITHUB_WORKSPACE}:/tmp/lint \
+          ghcr.io/github/super-linter:${GITHUB_SHA}

--- a/.github/workflows/deploy-DEV.yml
+++ b/.github/workflows/deploy-DEV.yml
@@ -57,10 +57,23 @@ jobs:
       ###################################
       # Build image locally for testing #
       ###################################
+
+      ##########################################
+      # Build and Push containers to registries #
+      ###########################################
+      - name: Build Docker slim image
+        run: |
+          docker build \
+          --build-arg BUILD_DATE=${{ env.BUILD_DATE }} \
+          --build-arg BUILD_REVISION=${{ github.sha }} \
+          --build-arg BUILD_VERSION=${{ github.sha }} \
+          -t ghcr.io/github/super-linter:${{ github.sha }}-slim \
+          -t ghcr.io/github/super-linter:test-slim -f Dockerfile-slim .
+
       ###########################################
       # Build and Push containers to registries #
       ###########################################
-      - name: Build Docker image
+      - name: Build Docker standard image
         run: |
           docker build \
           --build-arg BUILD_DATE=${{ env.BUILD_DATE }} \
@@ -136,7 +149,7 @@ jobs:
       #####################################
       # Run Linter against Test code base #
       #####################################
-      - name: Run Test Cases
+      - name: Run Test Cases - standard
         shell: bash
         run: |
           docker run \
@@ -147,6 +160,21 @@ jobs:
           -e ERROR_ON_MISSING_EXEC_BIT=true \
           -v ${GITHUB_WORKSPACE}:/tmp/lint \
           ghcr.io/github/super-linter:${GITHUB_SHA}
+
+      #####################################
+      # Run Linter against Test code base #
+      #####################################
+      - name: Run Test Cases - slim
+        shell: bash
+        run: |
+          docker run \
+          -e RUN_LOCAL=true \
+          -e TEST_CASE_RUN=true \
+          -e ANSIBLE_DIRECTORY=.automation/test/ansible \
+          -e ACTIONS_RUNNER_DEBUG=true \
+          -e ERROR_ON_MISSING_EXEC_BIT=true \
+          -v ${GITHUB_WORKSPACE}:/tmp/lint \
+          ghcr.io/github/super-linter:${GITHUB_SHA}-slim
 
       #########################################
       # Clean code base to run against it all #
@@ -168,3 +196,17 @@ jobs:
           -e ERROR_ON_MISSING_EXEC_BIT=true \
           -v ${GITHUB_WORKSPACE}:/tmp/lint \
           ghcr.io/github/super-linter:${GITHUB_SHA}
+
+      ############################################
+      # Run Linter against ALL cleaned code base #
+      ############################################
+      - name: Run against all code base - slim
+        shell: bash
+        run: |
+          docker run \
+          -e RUN_LOCAL=true \
+          -e OUTPUT_DETAILS=detailed \
+          -e ACTIONS_RUNNER_DEBUG=true \
+          -e ERROR_ON_MISSING_EXEC_BIT=true \
+          -v ${GITHUB_WORKSPACE}:/tmp/lint \
+          ghcr.io/github/super-linter:${GITHUB_SHA}-slim

--- a/.github/workflows/deploy-PROD.yml
+++ b/.github/workflows/deploy-PROD.yml
@@ -85,7 +85,7 @@ jobs:
       ###########################################
       # Build and Push containers to registries #
       ###########################################
-      - name: Build and push
+      - name: Build and push - Standard
         uses: docker/build-push-action@v2.4.0
         with:
           context: .
@@ -98,6 +98,23 @@ jobs:
           tags: |
             github/super-linter:latest
             ghcr.io/github/super-linter:latest
+
+      ###########################################
+      # Build and Push containers to registries #
+      ###########################################
+      - name: Build and push - SLIM
+        uses: docker/build-push-action@v2.4.0
+        with:
+          context: .
+          file: ./Dockerfile-slim
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            BUILD_REVISION=${{ github.sha }}
+            BUILD_VERSION=${{ github.sha }}
+          push: true
+          tags: |
+            github/super-linter:slim-latest
+            ghcr.io/github/super-linter:slim-latest
 
       #######################################################
       # Create a GitHub Issue with the info from this build #

--- a/.github/workflows/deploy-RELEASE.yml
+++ b/.github/workflows/deploy-RELEASE.yml
@@ -169,7 +169,9 @@ jobs:
       # Get the current date #
       ########################
       - name: Update Release Body String
-        run: echo "UPDATED_BODY_STRING=$(echo "${{ github.event.issue.body }}" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g')" >> ${GITHUB_ENV}
+        run: |
+          echo "UPDATED_BODY_STRING=$(echo "${{ github.event.issue.body }}" | \
+          sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g')" >> ${GITHUB_ENV}
 
       #############################
       # Create the GitHub Release #
@@ -178,16 +180,20 @@ jobs:
         if: success()
         id: create_release
         run: |
-          UPDATED_BODY_STRING=$(echo "${{ github.event.issue.body }}" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g')
+          UPDATED_BODY_STRING=$(echo "${{ github.event.issue.body }}" | \
+          sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g')
           curl --fail -X POST \
             --url https://api.github.com/repos/${{ github.repository }}/releases \
             -H 'Accept: application/vnd.github.v3+json' \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H 'Content-Type: application/json' \
-            --data "{ \"tag_name\": \"${{ env.RELEASE_VERSION }}\", \"target_commitish\": \"${{ env.PR_REF }}\", \
-              \"name\": \"Release ${{ env.RELEASE_VERSION }}\", \"draft\": false, \"prerelease\": false, \
+            --data "{ \"tag_name\": \"${{ env.RELEASE_VERSION }}\", \
+              \"target_commitish\": \"${{ env.PR_REF }}\", \
+              \"name\": \"Release ${{ env.RELEASE_VERSION }}\", \
+              \"draft\": false, \"prerelease\": false, \
               \"body\": \"${{ env.UPDATED_BODY_STRING }}\" \
-              \"repository_action_release_attributes\": { \"published_on_marketplace\": true }}"
+              \"repository_action_release_attributes\": \
+              { \"published_on_marketplace\": true }}"
 
       #####################################################
       # Create the Required status check for Stack Linter #

--- a/.github/workflows/deploy-RELEASE.yml
+++ b/.github/workflows/deploy-RELEASE.yml
@@ -126,7 +126,7 @@ jobs:
       ###########################################
       # Build and Push containers to registries #
       ###########################################
-      - name: Build and push
+      - name: Build and push - Standard
         uses: docker/build-push-action@v2.4.0
         with:
           context: .
@@ -143,6 +143,27 @@ jobs:
             ghcr.io/github/super-linter:latest
             ghcr.io/github/super-linter:v3
             ghcr.io/github/super-linter:${{ env.RELEASE_VERSION }}
+
+      ###########################################
+      # Build and Push containers to registries #
+      ###########################################
+      - name: Build and push - SLIM
+        uses: docker/build-push-action@v2.4.0
+        with:
+          context: .
+          file: ./Dockerfile-slim
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            BUILD_REVISION=${{ github.sha }}
+            BUILD_VERSION=${{ github.sha }}
+          push: true
+          tags: |
+            github/super-linter:slim-latest
+            github/super-linter:slim-v3
+            github/super-linter:slim-${{ env.RELEASE_VERSION }}
+            ghcr.io/github/super-linter:slim-latest
+            ghcr.io/github/super-linter:slim-v3
+            ghcr.io/github/super-linter:slim-${{ env.RELEASE_VERSION }}
 
       ########################
       # Get the current date #

--- a/.github/workflows/deploy-RELEASE.yml
+++ b/.github/workflows/deploy-RELEASE.yml
@@ -144,6 +144,12 @@ jobs:
             ghcr.io/github/super-linter:v3
             ghcr.io/github/super-linter:${{ env.RELEASE_VERSION }}
 
+      ########################
+      # Get the current date #
+      ########################
+      - name: Update Release Body String
+        run: echo "UPDATED_BODY_STRING=$(echo "${{ github.event.issue.body }}" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g')" >> ${GITHUB_ENV}
+
       #############################
       # Create the GitHub Release #
       #############################
@@ -159,7 +165,7 @@ jobs:
             -H 'Content-Type: application/json' \
             --data "{ \"tag_name\": \"${{ env.RELEASE_VERSION }}\", \"target_commitish\": \"${{ env.PR_REF }}\", \
               \"name\": \"Release ${{ env.RELEASE_VERSION }}\", \"draft\": false, \"prerelease\": false, \
-              \"body\": \"${UPDATED_BODY_STRING}\" \
+              \"body\": \"${{ env.UPDATED_BODY_STRING }}\" \
               \"repository_action_release_attributes\": { \"published_on_marketplace\": true }}"
 
       #####################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -233,7 +233,6 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
     && mv "ktlint" /usr/bin/ \
     && terrascan init \
     && cd ~ && touch .chktexrc \
-    && R -e "install.packages(list.dirs('/home/r-library',recursive = FALSE), repos = NULL, type = 'source')" \
 ####################
 # Install dart-sdk #
 ####################
@@ -377,6 +376,7 @@ COPY --from=base_image /node_modules/ /node_modules/
 # Install Litnr #
 #################
 COPY --from=lintr-lib /usr/lib/R/library/ /home/r-library
+RUN R -e "install.packages(list.dirs('/home/r-library',recursive = FALSE), repos = NULL, type = 'source')"
 
 ########################################
 # Add node packages to path and dotnet #

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ FROM accurics/terrascan:1.6.0 as terrascan
 FROM hadolint/hadolint:latest-alpine as dockerfile-lint
 FROM assignuser/chktex-alpine:v0.1.1 as chktex
 FROM garethr/kubeval:0.15.0 as kubeval
-FROM ghcr.io/assignuser/lintr-lib:0.2.0 as lintr-lib
 
 ##################
 # Get base image #
@@ -226,11 +225,6 @@ COPY --from=kubeval /kubeval /usr/bin/
 #################
 COPY --from=shfmt /bin/shfmt /usr/bin/
 
-#################
-# Install Litnr #
-#################
-COPY --from=lintr-lib /usr/lib/R/library/ /home/r-library
-
 ##################
 # Install ktlint #
 ##################
@@ -298,6 +292,7 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repo
 # Grab small clean image #######################################################
 ################################################################################
 FROM alpine:3.13.5 as final
+FROM ghcr.io/assignuser/lintr-lib:0.2.0 as lintr-lib
 
 ############################
 # Get the build arguements #
@@ -377,7 +372,11 @@ COPY --from=base_image /usr/include/ /usr/include/
 COPY --from=base_image /lib/ /lib/
 COPY --from=base_image /bin/ /bin/
 COPY --from=base_image /node_modules/ /node_modules/
-COPY --from=base_image /home/r-library /home/r-library
+
+#################
+# Install Litnr #
+#################
+COPY --from=lintr-lib /usr/lib/R/library/ /home/r-library
 
 ########################################
 # Add node packages to path and dotnet #

--- a/Dockerfile
+++ b/Dockerfile
@@ -291,8 +291,8 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repo
 ################################################################################
 # Grab small clean image #######################################################
 ################################################################################
-FROM alpine:3.13.5 as final
 FROM ghcr.io/assignuser/lintr-lib:0.2.0 as lintr-lib
+FROM alpine:3.13.5 as final
 
 ############################
 # Get the build arguements #

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -264,6 +264,7 @@ LABEL com.github.actions.name="GitHub Super-Linter" \
 ENV BUILD_DATE=$BUILD_DATE
 ENV BUILD_REVISION=$BUILD_REVISION
 ENV BUILD_VERSION=$BUILD_VERSION
+ENV IMAGE="slim"
 
 ######################################
 # Install Phive dependencies and git #

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -171,7 +171,6 @@ RUN curl --retry 5 --retry-delay 5 -sSLO https://github.com/pinterest/ktlint/rel
     && mv "ktlint" /usr/bin/ \
     && terrascan init \
     && cd ~ && touch .chktexrc \
-    && R -e "install.packages(list.dirs('/home/r-library',recursive = FALSE), repos = NULL, type = 'source')" \
 ####################
 # Install dart-sdk #
 ####################
@@ -313,6 +312,7 @@ COPY --from=base_image /node_modules/ /node_modules/
 # Install Litnr #
 #################
 COPY --from=lintr-lib /usr/lib/R/library/ /home/r-library
+RUN R -e "install.packages(list.dirs('/home/r-library',recursive = FALSE), repos = NULL, type = 'source')"
 
 ########################################
 # Add node packages to path and dotnet #

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -229,8 +229,8 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repo
 ################################################################################
 # Grab small clean image #######################################################
 ################################################################################
-FROM alpine:3.13.5 as final
 FROM ghcr.io/assignuser/lintr-lib:0.2.0 as lintr-lib
+FROM alpine:3.13.5 as final
 
 ############################
 # Get the build arguements #

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -9,6 +9,7 @@
 # - rust
 # - dotenv
 # - armttk
+# - pwsh
 
 #########################################
 # Get dependency images as build stages #

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -230,6 +230,7 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repo
 # Grab small clean image #######################################################
 ################################################################################
 FROM alpine:3.13.5 as final
+FROM ghcr.io/assignuser/lintr-lib:0.2.0 as lintr-lib
 
 ############################
 # Get the build arguements #
@@ -307,6 +308,11 @@ COPY --from=base_image /usr/include/ /usr/include/
 COPY --from=base_image /lib/ /lib/
 COPY --from=base_image /bin/ /bin/
 COPY --from=base_image /node_modules/ /node_modules/
+
+#################
+# Install Litnr #
+#################
+COPY --from=lintr-lib /usr/lib/R/library/ /home/r-library
 
 ########################################
 # Add node packages to path and dotnet #

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -1,14 +1,19 @@
 ###########################################
 ###########################################
 ## Dockerfile to run GitHub Super-Linter ##
+##              SLIM IMAGE               ##
 ###########################################
 ###########################################
+
+# Removed Linters:
+# - rust
+# - dotenv
+# - armttk
 
 #########################################
 # Get dependency images as build stages #
 #########################################
 FROM cljkondo/clj-kondo:2021.04.23-alpine as clj-kondo
-FROM dotenvlinter/dotenv-linter:3.0.0 as dotenv-linter
 FROM mstruebing/editorconfig-checker:2.3.5 as editorconfig-checker
 FROM yoheimuta/protolint:v0.31.0 as protolint
 FROM golangci/golangci-lint:v1.40.0 as golangci-lint
@@ -20,7 +25,6 @@ FROM accurics/terrascan:1.6.0 as terrascan
 FROM hadolint/hadolint:latest-alpine as dockerfile-lint
 FROM assignuser/chktex-alpine:v0.1.1 as chktex
 FROM garethr/kubeval:0.15.0 as kubeval
-FROM ghcr.io/assignuser/lintr-lib:0.2.0 as lintr-lib
 
 ##################
 # Get base image #
@@ -30,14 +34,6 @@ FROM python:3.9-alpine as base_image
 ################################
 # Set ARG values used in Build #
 ################################
-# PowerShell & PSScriptAnalyzer
-ARG PWSH_VERSION='latest'
-ARG PWSH_DIRECTORY='/usr/lib/microsoft/powershell'
-ARG PSSA_VERSION='latest'
-# arm-ttk
-ARG ARM_TTK_NAME='master.zip'
-ARG ARM_TTK_URI='https://github.com/Azure/arm-ttk/archive/master.zip'
-ARG ARM_TTK_DIRECTORY='/usr/lib/microsoft'
 # Dart Linter
 ## stable dart sdk: https://dart.dev/get-dart#release-channels
 ARG DART_VERSION='2.8.4'
@@ -49,6 +45,7 @@ ARG GLIBC_VERSION='2.31-r0'
 ####################
 RUN apk add --no-cache \
     bash \
+    cargo \
     coreutils \
     curl \
     file \
@@ -70,33 +67,11 @@ RUN apk add --no-cache \
     openjdk8-jre \
     openssl-dev \
     perl perl-dev \
-    py3-setuptools python3-dev\
+    py3-setuptools python3-dev \
     R R-dev R-doc \
     readline-dev \
     ruby ruby-dev ruby-bundler ruby-rdoc \
-    rustup \
     zlib zlib-dev
-
-##############################
-# Install rustfmt & clippy   #
-##############################
-ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
-RUN ln -s /usr/bin/rustup-init /usr/bin/rustup \
-    && rustup toolchain install stable-x86_64-unknown-linux-musl \
-    && rustup component add rustfmt --toolchain=stable-x86_64-unknown-linux-musl \
-    && rustup component add clippy --toolchain=stable-x86_64-unknown-linux-musl \
-    && mv /root/.rustup /usr/lib/.rustup \
-    && ln -s /usr/lib/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/rustfmt /usr/bin/rustfmt \
-    && ln -s /usr/lib/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/rustc /usr/bin/rustc \
-    && ln -s /usr/lib/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/cargo /usr/bin/cargo \
-    && ln -s /usr/lib/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/cargo-clippy /usr/bin/cargo-clippy \
-    && echo '#!/usr/bin/env bash' > /usr/bin/clippy \
-    && echo 'pushd $(dirname $1)' >> /usr/bin/clippy \
-    && echo 'cargo-clippy' >> /usr/bin/clippy \
-    && echo 'rc=$?' >> /usr/bin/clippy \
-    && echo 'popd' >> /usr/bin/clippy \
-    && echo 'exit $rc' >> /usr/bin/clippy \
-    && chmod +x /usr/bin/clippy
 
 ########################################
 # Copy dependencies files to container #
@@ -120,46 +95,12 @@ RUN pip3 install --no-cache-dir pipenv \
 ##############################
 # Installs ruby dependencies #
 ##############################
-    && bundle install \
-###################################
-# Install DotNet and Dependencies #
-###################################
-    && wget --tries=5 -q -O dotnet-install.sh https://dot.net/v1/dotnet-install.sh \
-    && chmod +x dotnet-install.sh \
-    && ./dotnet-install.sh --install-dir /usr/share/dotnet -channel Current -version latest \
-    && /usr/share/dotnet/dotnet tool install --tool-path /usr/bin dotnet-format --version 5.0.211103
+    && bundle install
 
 ##############################
 # Installs Perl dependencies #
 ##############################
-RUN curl --retry 5 --retry-delay 5 -sL https://cpanmin.us/ | perl - -nq --no-wget Perl::Critic \
-#########################################
-# Install Powershell + PSScriptAnalyzer #
-#########################################
-# Reference: https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-linux?view=powershell-7
-# Slightly modified to always retrieve latest stable Powershell version
-# If changing PWSH_VERSION='latest' to a specific version, use format PWSH_VERSION='tags/v7.0.2'
-    && mkdir -p ${PWSH_DIRECTORY} \
-    && curl --retry 5 --retry-delay 5 -s https://api.github.com/repos/powershell/powershell/releases/${PWSH_VERSION} \
-    | grep browser_download_url \
-    | grep linux-alpine-x64 \
-    | cut -d '"' -f 4 \
-    | xargs -n 1 wget -q -O - \
-    | tar -xzC ${PWSH_DIRECTORY} \
-    && ln -sf ${PWSH_DIRECTORY}/pwsh /usr/bin/pwsh \
-    && pwsh -c 'Install-Module -Name PSScriptAnalyzer -RequiredVersion ${PSSA_VERSION} -Scope AllUsers -Force'
-
-#############################################################
-# Install Azure Resource Manager Template Toolkit (arm-ttk) #
-#############################################################
-# Depends on PowerShell
-# Reference https://github.com/Azure/arm-ttk
-# Reference https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/test-toolkit
-ENV ARM_TTK_PSD1="${ARM_TTK_DIRECTORY}/arm-ttk-master/arm-ttk/arm-ttk.psd1"
-RUN curl --retry 5 --retry-delay 5 -sLO "${ARM_TTK_URI}" \
-    && unzip "${ARM_TTK_NAME}" -d "${ARM_TTK_DIRECTORY}" \
-    && rm "${ARM_TTK_NAME}" \
-    && ln -sTf "${ARM_TTK_PSD1}" /usr/bin/arm-ttk
+RUN curl --retry 5 --retry-delay 5 -sL https://cpanmin.us/ | perl - -nq --no-wget Perl::Critic
 
 ######################
 # Install shellcheck #
@@ -191,11 +132,6 @@ COPY --from=terragrunt /usr/local/bin/terragrunt /usr/bin/
 ######################
 COPY --from=protolint /usr/local/bin/protolint /usr/bin/
 
-#########################
-# Install dotenv-linter #
-#########################
-COPY --from=dotenv-linter /dotenv-linter /usr/bin/
-
 #####################
 # Install clj-kondo #
 #####################
@@ -225,11 +161,6 @@ COPY --from=kubeval /kubeval /usr/bin/
 # Install shfmt #
 #################
 COPY --from=shfmt /bin/shfmt /usr/bin/
-
-#################
-# Install Litnr #
-#################
-COPY --from=lintr-lib /usr/lib/R/library/ /home/r-library
 
 ##################
 # Install ktlint #
@@ -307,7 +238,6 @@ ARG BUILD_REVISION
 ARG BUILD_VERSION
 ## install alpine-pkg-glibc (glibc compatibility layer package for Alpine Linux)
 ARG GLIBC_VERSION='2.31-r0'
-ARG ARM_TTK_DIRECTORY='/usr/lib/microsoft'
 
 #########################################
 # Label the instance and set maintainer #
@@ -333,7 +263,6 @@ LABEL com.github.actions.name="GitHub Super-Linter" \
 ENV BUILD_DATE=$BUILD_DATE
 ENV BUILD_REVISION=$BUILD_REVISION
 ENV BUILD_VERSION=$BUILD_VERSION
-ENV ARM_TTK_PSD1="${ARM_TTK_DIRECTORY}/arm-ttk-master/arm-ttk/arm-ttk.psd1"
 
 ######################################
 # Install Phive dependencies and git #
@@ -376,13 +305,11 @@ COPY --from=base_image /usr/include/ /usr/include/
 COPY --from=base_image /lib/ /lib/
 COPY --from=base_image /bin/ /bin/
 COPY --from=base_image /node_modules/ /node_modules/
-COPY --from=base_image /home/r-library /home/r-library
 
 ########################################
 # Add node packages to path and dotnet #
 ########################################
-ENV PATH="${PATH}:/var/cache/dotnet/tools:/usr/share/dotnet:/node_modules/.bin"
-ENV ARM_TTK_PSD1="${ARM_TTK_DIRECTORY}/arm-ttk-master/arm-ttk/arm-ttk.psd1"
+ENV PATH="${PATH}:/node_modules/.bin"
 
 #############################
 # Copy scripts to container #
@@ -397,7 +324,7 @@ COPY TEMPLATES /action/lib/.automation
 ################################################
 # Run to build version file and validate image #
 ################################################
-RUN ACTIONS_RUNNER_DEBUG=true WRITE_LINTER_VERSIONS_FILE=true /action/lib/linter.sh
+RUN ACTIONS_RUNNER_DEBUG=true WRITE_LINTER_VERSIONS_FILE=true IMAGE=slim /action/lib/linter.sh
 
 ######################
 # Set the entrypoint #

--- a/Makefile
+++ b/Makefile
@@ -73,12 +73,15 @@ inspec-check: ## Validate inspec profiles
 SUPER_LINTER_TEST_CONTAINER_NAME := "super-linter-test"
 SUPER_LINTER_TEST_CONTINER_URL := ''
 DOCKERFILE := ''
+IMAGE := ''
 ifeq ($(IMAGE),slim)
 	SUPER_LINTER_TEST_CONTINER_URL := "ghcr.io/github/super-linter:slim-test"
 	DOCKERFILE := "Dockerfile-slim"
+	IMAGE := "slim"
 else
 	SUPER_LINTER_TEST_CONTINER_URL := "ghcr.io/github/super-linter:test"
 	DOCKERFILE := "Dockerfile"
+	IMAGE := "standard"
 endif
 
 .PHONY: inspec
@@ -91,6 +94,7 @@ inspec: inspec-check ## Run InSpec tests
 		--rm \
 		-v "$(CURDIR)":/workspace \
 		-v /var/run/docker.sock:/var/run/docker.sock \
+		-e IMAGE=$(IMAGE)
 		-w="/workspace" \
 		chef/inspec exec test/inspec/super-linter\
 		--chef-license=accept \

--- a/Makefile
+++ b/Makefile
@@ -72,17 +72,20 @@ inspec-check: ## Validate inspec profiles
 
 SUPER_LINTER_TEST_CONTAINER_NAME := "super-linter-test"
 SUPER_LINTER_TEST_CONTINER_URL := ''
+DOCKERFILE := ''
 ifeq ($(IMAGE),slim)
 	SUPER_LINTER_TEST_CONTINER_URL := "ghcr.io/github/super-linter:slim-test"
+	DOCKERFILE := "Dockerfile-slim"
 else
 	SUPER_LINTER_TEST_CONTINER_URL := "ghcr.io/github/super-linter:test"
+	DOCKERFILE := "Dockerfile"
 endif
 
 .PHONY: inspec
 inspec: inspec-check ## Run InSpec tests
 	DOCKER_CONTAINER_STATE="$$(docker inspect --format "{{.State.Running}}" "$(SUPER_LINTER_TEST_CONTAINER_NAME)" 2>/dev/null || echo "")"; \
 	if [ "$$DOCKER_CONTAINER_STATE" = "true" ]; then docker kill "$(SUPER_LINTER_TEST_CONTAINER_NAME)"; fi && \
-	docker build -t $(SUPER_LINTER_TEST_CONTAINER_NAME) -f Dockerfile . && \
+	docker build -t $(SUPER_LINTER_TEST_CONTAINER_NAME) -f $(DOCKERFILE) . && \
 	SUPER_LINTER_TEST_CONTAINER_ID="$$(docker run -d --name "$(SUPER_LINTER_TEST_CONTAINER_NAME)" --rm -it --entrypoint /bin/ash "$(SUPER_LINTER_TEST_CONTAINER_NAME)" -c "while true; do sleep 1; done")" \
 	&& docker run $(DOCKER_FLAGS) \
 		--rm \

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,12 @@ inspec-check: ## Validate inspec profiles
 		test/inspec/super-linter
 
 SUPER_LINTER_TEST_CONTAINER_NAME := "super-linter-test"
-SUPER_LINTER_TEST_CONTINER_URL := "ghcr.io/github/super-linter:test"
+SUPER_LINTER_TEST_CONTINER_URL := ''
+ifeq ($(IMAGE),slim)
+	SUPER_LINTER_TEST_CONTINER_URL := "ghcr.io/github/super-linter:slim-test"
+else
+	SUPER_LINTER_TEST_CONTINER_URL := "ghcr.io/github/super-linter:test"
+endif
 
 .PHONY: inspec
 inspec: inspec-check ## Run InSpec tests

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ inspec: inspec-check ## Run InSpec tests
 		--rm \
 		-v "$(CURDIR)":/workspace \
 		-v /var/run/docker.sock:/var/run/docker.sock \
-		-e IMAGE=$(IMAGE)
+		-e IMAGE=$(IMAGE) \
 		-w="/workspace" \
 		chef/inspec exec test/inspec/super-linter\
 		--chef-license=accept \

--- a/README.md
+++ b/README.md
@@ -201,16 +201,16 @@ _Note:_ IF you did not use `Lint Code Base` as GitHub Action name, please read [
 
 ### Images
 
-The **GitHub Super-Linter** now builds and supports `multiple` images. We have found as we added more linters, the image size expanded drastically.  
-After further investigation, we were able to see that a few linters were very disk heavy. We removed those linters and created the `slim` image.  
-This allows users to choose which **Super-Linter** they want to run and potentially speed up their build time.  
+The **GitHub Super-Linter** now builds and supports `multiple` images. We have found as we added more linters, the image size expanded drastically.
+After further investigation, we were able to see that a few linters were very disk heavy. We removed those linters and created the `slim` image.
+This allows users to choose which **Super-Linter** they want to run and potentially speed up their build time.
 The available images:
 - `github/super-linter:v4`
 - `github/super-linter:slim-v4`
 
 #### Standard Image
 
-The standard `github/super-linter:v4` comes with all supported linters.  
+The standard `github/super-linter:v4` comes with all supported linters.
 Example usage:
 ```yml
 ################################
@@ -231,8 +231,8 @@ The slim `github/super-linter:slim-v4` comes with all supported linters but remo
 - `dotenv` linters
 - `armttk` linters
 - `pwsh` linters
-By removing these linters, we were able to bring the image size down by `2gb` and drastically speed up the build and download time.  
-The behavior will be the same for non-supported languages, and will skip languages at run time.  
+By removing these linters, we were able to bring the image size down by `2gb` and drastically speed up the build and download time.
+The behavior will be the same for non-supported languages, and will skip languages at run time.
 Example usage:
 ```yml
 ################################

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ It is a simple combination of various linters, written in `bash`, to help valida
   - [How to use](#how-to-use)
     - [Example connecting GitHub Action Workflow](#example-connecting-github-action-workflow)
     - [Add Super-Linter badge in your repository README](#add-super-linter-badge-in-your-repository-readme)
+    - [Images](#images)
+      - [Standard Image](#standard-image)
+      - [Slim Image](#slim-image)
   - [Environment variables](#environment-variables)
     - [Template rules files](#template-rules-files)
     - [Using your own rules files](#using-your-own-rules-files)
@@ -195,6 +198,53 @@ Example:
 ```
 
 _Note:_ IF you did not use `Lint Code Base` as GitHub Action name, please read [GitHub Actions Badges documentation](https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository)
+
+### Images
+
+The **GitHub Super-Linter** now builds and supports `multiple` images. We have found as we added more linters, the image size expanded drastically.  
+After further investigation, we were able to see that a few linters were very disk heavy. We removed those linters and created the `slim` image.  
+This allows users to choose which **Super-Linter** they want to run and potentially speed up their build time.  
+The available images:
+- `github/super-linter:v4`
+- `github/super-linter:slim-v4`
+
+#### Standard Image
+
+The standard `github/super-linter:v4` comes with all supported linters.  
+Example usage:
+```yml
+################################
+# Run Linter against code base #
+################################
+- name: Lint Code Base
+  uses: github/super-linter@v4
+  env:
+    VALIDATE_ALL_CODEBASE: false
+    DEFAULT_BRANCH: master
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+#### Slim Image
+
+The slim `github/super-linter:slim-v4` comes with all supported linters but removes the following:
+- `rust` linters
+- `dotenv` linters
+- `armttk` linters
+- `pwsh` linters
+By removing these linters, we were able to bring the image size down by `2gb` and drastically speed up the build and download time.  
+The behavior will be the same for non-supported languages, and will skip languages at run time.  
+Example usage:
+```yml
+################################
+# Run Linter against code base #
+################################
+- name: Lint Code Base
+  uses: github/super-linter@slim-v4
+  env:
+    VALIDATE_ALL_CODEBASE: false
+    DEFAULT_BRANCH: master
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
 
 ## Environment variables
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Example usage:
 # Run Linter against code base #
 ################################
 - name: Lint Code Base
-  uses: github/super-linter@slim-v4
+  uses: ghcr.io://github/super-linter@slim-v4
   env:
     VALIDATE_ALL_CODEBASE: false
     DEFAULT_BRANCH: master

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -700,13 +700,15 @@ UpdateLoopsForImage() {
 
     # Remove from LANGUAGE_ARRAY
     for REMOVE_LANGUAGE in "${REMOVE_LANGUAGE_ARRAY[@]}"; do
-      LANGUAGE_ARRAY=("${LANGUAGE_ARRAY[@]/$REMOVE_LANGUAGE}")
+      #shellcheck disable=SC2190
+      LANGUAGE_ARRAY=("${LANGUAGE_ARRAY[@]/$REMOVE_LANGUAGE/}")
       echo "Removing Language:[${REMOVE_LANGUAGE}] from [LANGUAGE_ARRAY]"
     done
 
     # Remove from LINTER_NAMES_ARRAY
     for REMOVE_LINTER in "${REMOVE_LINTER_ARRAY[@]}"; do
-      LINTER_NAMES_ARRAY=("${LINTER_NAMES_ARRAY[@]/$REMOVE_LINTER}")
+      #shellcheck disable=SC2190
+      LINTER_NAMES_ARRAY=("${LINTER_NAMES_ARRAY[@]/$REMOVE_LINTER/}")
       echo "Removing Language:[${REMOVE_LINTER}] from [LINTER_NAMES_ARRAY]"
     done
   fi

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -12,6 +12,7 @@
 ##################################################################
 # RUN_LOCAL="${RUN_LOCAL}"                            # Boolean to see if we are running locally
 ACTIONS_RUNNER_DEBUG="${ACTIONS_RUNNER_DEBUG:-false}" # Boolean to see even more info (debug)
+IMAGE="${IMAGE:-standard}"                            # Version of the Super-linter (standard,slim,etc)
 
 ##################################################################
 # Log Vars                                                       #
@@ -685,6 +686,32 @@ Footer() {
   exit 0
 }
 ################################################################################
+#### Function UpdateLoopsForImage ##############################################
+UpdateLoopsForImage() {
+  ######################################################################
+  # Need to clean the array lists of the linters removed for the image #
+  ######################################################################
+  if [[ "${IMAGE}" == "slim" ]]; then
+    #############################################
+    # Need to remove linters for the slim image #
+    #############################################
+    REMOVE_LANGUAGE_ARRAY=("ARM" "ENV" "RUST_2015" "RUST_2018" "RUST_CLIPPY")
+    REMOVE_LINTER_ARRAY=("arm-ttk" "dotenv-linter" "rustfmt" "clippy")
+
+    # Remove from LANGUAGE_ARRAY
+    for REMOVE_LANGUAGE in "${REMOVE_LANGUAGE_ARRAY[@]}"; do
+      LANGUAGE_ARRAY=("${LANGUAGE_ARRAY[@]/$REMOVE_LANGUAGE}")
+      echo "Removing Language:[${REMOVE_LANGUAGE}] from [LANGUAGE_ARRAY]"
+    done
+
+    # Remove from LINTER_NAMES_ARRAY
+    for REMOVE_LINTER in "${REMOVE_LINTER_ARRAY[@]}"; do
+      LINTER_NAMES_ARRAY=("${LINTER_NAMES_ARRAY[@]/$REMOVE_LINTER}")
+      echo "Removing Language:[${REMOVE_LINTER}] from [LINTER_NAMES_ARRAY]"
+    done
+  fi
+}
+################################################################################
 #### Function Cleanup ##########################################################
 cleanup() {
   local -ri EXIT_CODE=$?
@@ -703,6 +730,11 @@ trap 'cleanup' 0 1 2 3 6 14 15
 # Header #
 ##########
 Header
+
+################################################
+# Need to update the loops for the image style #
+################################################
+UpdateLoopsForImage
 
 ##################################
 # Get and print all version info #

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -695,21 +695,28 @@ UpdateLoopsForImage() {
     #############################################
     # Need to remove linters for the slim image #
     #############################################
-    REMOVE_LANGUAGE_ARRAY=("ARM" "ENV" "RUST_2015" "RUST_2018" "RUST_CLIPPY")
-    REMOVE_LINTER_ARRAY=("arm-ttk" "dotenv-linter" "rustfmt" "clippy")
+    REMOVE_ARRAY=("ARM" "CSHARP" "ENV" "POWERSHELL" "RUST_2015" "RUST_2018" "RUST_CLIPPY")
 
     # Remove from LANGUAGE_ARRAY
-    for REMOVE_LANGUAGE in "${REMOVE_LANGUAGE_ARRAY[@]}"; do
-      #shellcheck disable=SC2190
-      LANGUAGE_ARRAY=("${LANGUAGE_ARRAY[@]/$REMOVE_LANGUAGE//}")
-      echo "Removing Language:[${REMOVE_LANGUAGE}] from [LANGUAGE_ARRAY]"
+    echo "Removing Languages from LANGUAGE_ARRAY for slim image..."
+    for REMOVE_LANGUAGE in "${REMOVE_ARRAY[@]}"; do
+      for INDEX in "${!LANGUAGE_ARRAY[@]}"; do
+        if [[ ${LANGUAGE_ARRAY[INDEX]} = ${REMOVE_LANGUAGE} ]]; then
+          echo "found item:[${REMOVE_LANGUAGE}], removing Language..."
+          unset 'LANGUAGE_ARRAY[INDEX]'
+        fi
+      done
     done
 
     # Remove from LINTER_NAMES_ARRAY
-    for REMOVE_LINTER in "${REMOVE_LINTER_ARRAY[@]}"; do
-      #shellcheck disable=SC2190
-      LINTER_NAMES_ARRAY=("${LINTER_NAMES_ARRAY[@]/$REMOVE_LINTER//}")
-      echo "Removing Language:[${REMOVE_LINTER}] from [LINTER_NAMES_ARRAY]"
+    echo "Removing Linters from LINTER_NAMES_ARRAY for slim image..."
+    for REMOVE_LINTER in "${REMOVE_ARRAY[@]}"; do
+      for INDEX in "${!LINTER_NAMES_ARRAY[@]}"; do
+        if [[ ${INDEX} = ${REMOVE_LINTER} ]]; then
+          echo "found item:[${REMOVE_LINTER}], removing linter..."
+          unset 'LINTER_NAMES_ARRAY[$INDEX]'
+        fi
+      done
     done
   fi
 }

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -701,7 +701,7 @@ UpdateLoopsForImage() {
     echo "Removing Languages from LANGUAGE_ARRAY for slim image..."
     for REMOVE_LANGUAGE in "${REMOVE_ARRAY[@]}"; do
       for INDEX in "${!LANGUAGE_ARRAY[@]}"; do
-        if [[ ${LANGUAGE_ARRAY[INDEX]} = ${REMOVE_LANGUAGE} ]]; then
+        if [[ ${LANGUAGE_ARRAY[INDEX]} = "${REMOVE_LANGUAGE}" ]]; then
           echo "found item:[${REMOVE_LANGUAGE}], removing Language..."
           unset 'LANGUAGE_ARRAY[INDEX]'
         fi
@@ -712,7 +712,7 @@ UpdateLoopsForImage() {
     echo "Removing Linters from LINTER_NAMES_ARRAY for slim image..."
     for REMOVE_LINTER in "${REMOVE_ARRAY[@]}"; do
       for INDEX in "${!LINTER_NAMES_ARRAY[@]}"; do
-        if [[ ${INDEX} = ${REMOVE_LINTER} ]]; then
+        if [[ ${INDEX} = "${REMOVE_LINTER}" ]]; then
           echo "found item:[${REMOVE_LINTER}], removing linter..."
           unset 'LINTER_NAMES_ARRAY[$INDEX]'
         fi

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -701,14 +701,14 @@ UpdateLoopsForImage() {
     # Remove from LANGUAGE_ARRAY
     for REMOVE_LANGUAGE in "${REMOVE_LANGUAGE_ARRAY[@]}"; do
       #shellcheck disable=SC2190
-      LANGUAGE_ARRAY=("${LANGUAGE_ARRAY[@]/$REMOVE_LANGUAGE/}")
+      LANGUAGE_ARRAY=("${LANGUAGE_ARRAY[@]/$REMOVE_LANGUAGE}")
       echo "Removing Language:[${REMOVE_LANGUAGE}] from [LANGUAGE_ARRAY]"
     done
 
     # Remove from LINTER_NAMES_ARRAY
     for REMOVE_LINTER in "${REMOVE_LINTER_ARRAY[@]}"; do
       #shellcheck disable=SC2190
-      LINTER_NAMES_ARRAY=("${LINTER_NAMES_ARRAY[@]/$REMOVE_LINTER/}")
+      LINTER_NAMES_ARRAY=("${LINTER_NAMES_ARRAY[@]/$REMOVE_LINTER}")
       echo "Removing Language:[${REMOVE_LINTER}] from [LINTER_NAMES_ARRAY]"
     done
   fi

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -701,14 +701,14 @@ UpdateLoopsForImage() {
     # Remove from LANGUAGE_ARRAY
     for REMOVE_LANGUAGE in "${REMOVE_LANGUAGE_ARRAY[@]}"; do
       #shellcheck disable=SC2190
-      LANGUAGE_ARRAY=("${LANGUAGE_ARRAY[@]/$REMOVE_LANGUAGE}")
+      LANGUAGE_ARRAY=("${LANGUAGE_ARRAY[@]/$REMOVE_LANGUAGE//}")
       echo "Removing Language:[${REMOVE_LANGUAGE}] from [LANGUAGE_ARRAY]"
     done
 
     # Remove from LINTER_NAMES_ARRAY
     for REMOVE_LINTER in "${REMOVE_LINTER_ARRAY[@]}"; do
       #shellcheck disable=SC2190
-      LINTER_NAMES_ARRAY=("${LINTER_NAMES_ARRAY[@]/$REMOVE_LINTER}")
+      LINTER_NAMES_ARRAY=("${LINTER_NAMES_ARRAY[@]/$REMOVE_LINTER//}")
       echo "Removing Language:[${REMOVE_LINTER}] from [LINTER_NAMES_ARRAY]"
     done
   fi

--- a/test/inspec/super-linter/controls/super_linter.rb
+++ b/test/inspec/super-linter/controls/super_linter.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# PUll in env vars passed
+image = ENV["IMAGE"]
+
 ##################################################
 # Check to see all system packages are installed #
 ##################################################
@@ -62,7 +65,6 @@ control "super-linter-installed-packages" do
       it { should be_installed }
     end
   end
-
 end
 
 ###########################################
@@ -140,53 +142,69 @@ control "super-linter-installed-commands" do
     { linter_name: "yamllint"},
   ]
 
+  # Removed linters from slim image
+  SLIM_IMAGE_REMOVED_LINTERS=%w(
+    arm-ttk
+    clippy
+    dotnet-format
+    dotenv-linter
+    pwsh
+    rustfmt
+  )
+
   linters.each do |linter|
     # If we didn't specify a linter command, use the linter name as a linter
     # command because the vast majority of linters have name == command
-    if(linter.key?(:linter_command))
-      linter_command = linter[:linter_command]
+    linter_command = ""
+
+    if(image == "slim" && SLIM_IMAGE_REMOVED_LINTERS.include?(linter[:linter_name]))
+      continue
     else
-      linter_command = linter[:linter_name]
-    end
-
-    describe command("command -v #{linter_command}") do
-      its("exit_status") { should eq 0 }
-    end
-
-    # A few linters have a command that it's different than linter_command
-    if(linter.key?(:version_command))
-      version_command = linter[:version_command]
-    else
-      # Check if the linter needs an option that is different from the one that
-      # the vast majority of linters use to get the version
-      if(linter.key?(:version_option))
-        version_option = linter[:version_option]
+      if(linter.key?(:linter_command))
+        linter_command = linter[:linter_command]
       else
-        version_option = default_version_option
+        linter_command = linter[:linter_name]
       end
 
-      version_command = "#{linter_command} #{version_option}"
-
-      if(linter.key?(:expected_exit_status))
-        expected_exit_status = linter[:expected_exit_status]
-      else
-        expected_exit_status = default_version_expected_exit_status
+      describe command("command -v #{linter_command}") do
+        its("exit_status") { should eq 0 }
       end
 
-      if(linter.key?(:expected_stdout_regex))
-        expected_stdout_regex = linter[:expected_stdout_regex]
+      # A few linters have a command that it's different than linter_command
+      if(linter.key?(:version_command))
+        version_command = linter[:version_command]
       else
-        expected_stdout_regex = default_expected_stdout_regex
-      end
+        # Check if the linter needs an option that is different from the one that
+        # the vast majority of linters use to get the version
+        if(linter.key?(:version_option))
+          version_option = linter[:version_option]
+        else
+          version_option = default_version_option
+        end
 
-      ##########################################################
-      # Being able to run the command `linter --version` helps #
-      # achieve that the linter is installed, ini PATH, and    #
-      # has the libraries needed to be able to basically run   #
-      ##########################################################
-      describe command(version_command) do
-        its("exit_status") { should eq expected_exit_status }
-        its("stdout") { should match (expected_stdout_regex) }
+        version_command = "#{linter_command} #{version_option}"
+
+        if(linter.key?(:expected_exit_status))
+          expected_exit_status = linter[:expected_exit_status]
+        else
+          expected_exit_status = default_version_expected_exit_status
+        end
+
+        if(linter.key?(:expected_stdout_regex))
+          expected_stdout_regex = linter[:expected_stdout_regex]
+        else
+          expected_stdout_regex = default_expected_stdout_regex
+        end
+
+        ##########################################################
+        # Being able to run the command `linter --version` helps #
+        # achieve that the linter is installed, ini PATH, and    #
+        # has the libraries needed to be able to basically run   #
+        ##########################################################
+        describe command(version_command) do
+          its("exit_status") { should eq expected_exit_status }
+          its("stdout") { should match (expected_stdout_regex) }
+        end
       end
     end
   end
@@ -328,10 +346,19 @@ control "super-linter-validate-directories" do
     "/usr/local/share/"
   ]
 
-  dirs.each do |item|
-    describe directory(item) do
-      it { should exist }
-      it { should be_directory }
+  # Removed linters from slim image
+  SLIM_IMAGE_REMOVED_DIRS=%w(
+    /home/r-library
+  )
+
+  if(image == "slim" && SLIM_IMAGE_REMOVED_DIRS.include?(item)
+    continue
+  else
+    dirs.each do |item|
+      describe directory(item) do
+        it { should exist }
+        it { should be_directory }
+      end
     end
   end
 end
@@ -412,13 +439,17 @@ control "super-linter-validate-powershell-modules" do
   title "Super-Linter validate Powershell Modules"
   desc "Check that Powershell modules that Super-Linter needs are installed."
 
-  describe command("pwsh -c \"(Get-Module -Name PSScriptAnalyzer -ListAvailable | Select-Object -First 1).Name\" 2>&1") do
-    its("exit_status") { should eq 0 }
-    its("stdout") { should eq "PSScriptAnalyzer\n" }
-  end
+  if(image == "slim" && SLIM_IMAGE_REMOVED_DIRS.include?(item)
+    continue
+  else
+    describe command("pwsh -c \"(Get-Module -Name PSScriptAnalyzer -ListAvailable | Select-Object -First 1).Name\" 2>&1") do
+      its("exit_status") { should eq 0 }
+      its("stdout") { should eq "PSScriptAnalyzer\n" }
+    end
 
-  describe command("pwsh -c \"(Get-Command Invoke-ScriptAnalyzer | Select-Object -First 1).Name\" 2>&1") do
-    its("exit_status") { should eq 0 }
-    its("stdout") { should eq "Invoke-ScriptAnalyzer\n" }
+    describe command("pwsh -c \"(Get-Command Invoke-ScriptAnalyzer | Select-Object -First 1).Name\" 2>&1") do
+      its("exit_status") { should eq 0 }
+      its("stdout") { should eq "Invoke-ScriptAnalyzer\n" }
+    end
   end
 end

--- a/test/inspec/super-linter/controls/super_linter.rb
+++ b/test/inspec/super-linter/controls/super_linter.rb
@@ -60,9 +60,18 @@ control "super-linter-installed-packages" do
     "zlib"
   ]
 
+  # Removed linters from slim image
+  SLIM_IMAGE_REMOVED_PACKAGES=%w(
+    rustup
+  )
+
   packages.each do |item|
-    describe package(item) do
-      it { should be_installed }
+    if(image == "slim" && SLIM_IMAGE_REMOVED_PACKAGES.include?(item))
+      next
+    else
+      describe package(item) do
+        it { should be_installed }
+      end
     end
   end
 end
@@ -158,7 +167,7 @@ control "super-linter-installed-commands" do
     linter_command = ""
 
     if(image == "slim" && SLIM_IMAGE_REMOVED_LINTERS.include?(linter[:linter_name]))
-      continue
+      next
     else
       if(linter.key?(:linter_command))
         linter_command = linter[:linter_command]
@@ -351,10 +360,10 @@ control "super-linter-validate-directories" do
     /home/r-library
   )
 
-  if(image == "slim" && SLIM_IMAGE_REMOVED_DIRS.include?(item))
-    continue
-  else
-    dirs.each do |item|
+  dirs.each do |item|
+    if(image == "slim" && SLIM_IMAGE_REMOVED_DIRS.include?(item))
+      next
+    else
       describe directory(item) do
         it { should exist }
         it { should be_directory }
@@ -439,8 +448,8 @@ control "super-linter-validate-powershell-modules" do
   title "Super-Linter validate Powershell Modules"
   desc "Check that Powershell modules that Super-Linter needs are installed."
 
-  if(image == "slim" && SLIM_IMAGE_REMOVED_DIRS.include?(item))
-    continue
+  if(image == "slim")
+    next
   else
     describe command("pwsh -c \"(Get-Module -Name PSScriptAnalyzer -ListAvailable | Select-Object -First 1).Name\" 2>&1") do
       its("exit_status") { should eq 0 }

--- a/test/inspec/super-linter/controls/super_linter.rb
+++ b/test/inspec/super-linter/controls/super_linter.rb
@@ -351,7 +351,7 @@ control "super-linter-validate-directories" do
     /home/r-library
   )
 
-  if(image == "slim" && SLIM_IMAGE_REMOVED_DIRS.include?(item)
+  if(image == "slim" && SLIM_IMAGE_REMOVED_DIRS.include?(item))
     continue
   else
     dirs.each do |item|
@@ -439,7 +439,7 @@ control "super-linter-validate-powershell-modules" do
   title "Super-Linter validate Powershell Modules"
   desc "Check that Powershell modules that Super-Linter needs are installed."
 
-  if(image == "slim" && SLIM_IMAGE_REMOVED_DIRS.include?(item)
+  if(image == "slim" && SLIM_IMAGE_REMOVED_DIRS.include?(item))
     continue
   else
     describe command("pwsh -c \"(Get-Module -Name PSScriptAnalyzer -ListAvailable | Select-Object -First 1).Name\" 2>&1") do


### PR DESCRIPTION
This is a major change...

- Adding the additional image  file `Dockerfile-slim`
- This will remove the heaviest linters from the image to bring the size down almost `2GB
- Needed to update the tests to help deploy this as well...

## Linters removed in slim image
- `arm-ttk`
- `csharp`
- `pwsh`
- `rust`

The 3 windows linters are all reliant on PowerShell and take up around 1.3GB of space in the superliner
The Rust linter takes over 1GB of space for its libraries...

As you can see removing this takes the image down to half...

## Images
As we move towards `4.x` of the super linter we will have the following 2 images:
- `github/super-linter:4.x.y`
- `github/super-linter:slim-4.x.y`

This will allow for more images to be made as needed but helps pull in the build times for a dramatic amount of our users.

## Automation
We added additional automation to build out and test the images in parallel.
This also required some small updates to file names, flags passed and molding some loops...
Overall, this leads us in a fun new direction :)