### PR TITLE
docs: added missing c# to list of slim removed langs

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ The slim `github/super-linter:slim-v4` comes with all supported linters but remo
 - `dotenv` linters
 - `armttk` linters
 - `pwsh` linters
+- `c#` linters
 By removing these linters, we were able to bring the image size down by `2gb` and drastically speed up the build and download time.
 The behavior will be the same for non-supported languages, and will skip languages at run time.
 Example usage:


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

`CSHARP` is removed from the `slim image` but is not listed in the documentation.

## Proposed Changes

Added `c#` to the `slim image` removed list in `README.md`.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
