### PR TITLE
Update deploy-RELEASE-slim.yml

### DIFF
--- a/.github/workflows/deploy-RELEASE-slim.yml
+++ b/.github/workflows/deploy-RELEASE-slim.yml
@@ -106,6 +106,15 @@ jobs:
           username: ${{ secrets.GCR_USERNAME }}
           password: ${{ secrets.GCR_TOKEN }}
           registry: ghcr.io
+      
+      ###########################
+      # Get the current release #
+      ###########################
+      - name: Get current Release number
+        run: |
+          echo "RELEASE_VERSION=$(echo "${{ github.event.issue.title }}" \
+          | grep -E -o "v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+")" \
+          >> ${GITHUB_ENV}
 
       ###########################################
       # Build and Push containers to registries #

--- a/.github/workflows/deploy-RELEASE-slim.yml
+++ b/.github/workflows/deploy-RELEASE-slim.yml
@@ -106,7 +106,7 @@ jobs:
           username: ${{ secrets.GCR_USERNAME }}
           password: ${{ secrets.GCR_TOKEN }}
           registry: ghcr.io
-      
+
       ###########################
       # Get the current release #
       ###########################


### PR DESCRIPTION
This closes #1612 

Seems there was an oversight that we were not setting the `RELEASE_VERSION` env var when we split the image into 2 runs.
This fixes that and builds the version info on the release run for `slim`