### PR TITLE
Fix README issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ The available images:
 
 The standard `github/super-linter:v4` comes with all supported linters.
 Example usage:
+
 ```yml
 ################################
 # Run Linter against code base #
@@ -228,14 +229,17 @@ Example usage:
 #### Slim Image
 
 The slim `github/super-linter:slim-v4` comes with all supported linters but removes the following:
+
 - `rust` linters
 - `dotenv` linters
 - `armttk` linters
 - `pwsh` linters
 - `c#` linters
+
 By removing these linters, we were able to bring the image size down by `2gb` and drastically speed up the build and download time.
 The behavior will be the same for non-supported languages, and will skip languages at run time.
 Example usage:
+
 ```yml
 ################################
 # Run Linter against code base #
@@ -428,7 +432,9 @@ We will also support [GitHub Codespaces](https://github.com/features/codespaces/
 If you need to inject a SSL cert into the trust store, you will need to first copy the cert to **GitHub Secrets**
 Once you have copied the plain text certificate into **GitHub Secrets**, you can use the variable `SSL_CERT_SECRET` to point the **Super-Linter** to the files contents.
 Once found, it will load the certificate contents to a file, and to the trust store.
+
 - Example workflow:
+
 ```yml
 - name: Lint Code Base
   uses: github/super-linter@v4
@@ -439,7 +445,7 @@ Once found, it will load the certificate contents to a file, and to the trust st
 
 ## Community Activity
 
-<img src="https://cauldron.io/project/2083/stats.svg" >
+![super-linter stats](https://cauldron.io/project/2083/stats.svg)
 
 ## Limitations
 


### PR DESCRIPTION
## Proposed Changes

This PR fixes some linting issues in README

1. Missing blank line before lists.
2. Missing blank line before code blocks
3. Embed the GitHub repo stats image with Markdown instead of an HTML tag.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
