### PR TITLE
Fix terragrunt file picker from selecting packer files

### DIFF
--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -700,7 +700,7 @@ function BuildFileList() {
     ############################
     # Get the Terragrunt files #
     ############################
-    elif [ "${FILE_TYPE}" == "hcl" ] && [[ ${FILE} != *".tflint.hcl"* ]]; then
+    elif [ "${FILE_TYPE}" == "hcl" ] && [[ ${FILE} != *".tflint.hcl"* ]] && [[ ${FILE} != *".pkr.hcl"* ]]; then
       ################################
       # Append the file to the array #
       ################################


### PR DESCRIPTION
Add a check to the terragrunt file builder to not select packer files when it building.

## Proposed Changes

This will cause terragrunt linter to stop running against packer files 

## Linked Issue
[issue1708](https://github.com/github/super-linter/issues/1708)
## Readiness Checklist

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
