### PR TITLE
docs(dockerfile-slim): fix typo

### DIFF
--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -234,7 +234,7 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repo
     && find /usr/ -type f -name '*.md' -exec rm {} +
 
 ################################################################################
-# Build the clang-form binary ##################################################
+# Build the clang-format binary ################################################
 ################################################################################
 FROM alpine:3.14.0 as clang-format-build
 


### PR DESCRIPTION
This fixes small typo introduced in #1764.
Just happened to see it, hope this is not too trivial to be a PR :)

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Readiness Checklist

### Author/Contributor
- [X] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
