### PR TITLE
Switch from wata727/tflint to ghcr.io/terraform-linters/tflint-bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM mstruebing/editorconfig-checker:2.3.5 as editorconfig-checker
 FROM yoheimuta/protolint:v0.32.0 as protolint
 FROM golangci/golangci-lint:v1.41.1 as golangci-lint
 FROM koalaman/shellcheck:v0.7.2 as shellcheck
-FROM wata727/tflint:0.29.1 as tflint
+FROM ghcr.io/terraform-linters/tflint-bundle:v0.30.0 as tflint
 FROM alpine/terragrunt:1.0.1 as terragrunt
 FROM mvdan/shfmt:v3.3.0 as shfmt
 FROM accurics/terrascan:1.8.0 as terrascan
@@ -176,6 +176,7 @@ COPY --from=golangci-lint /usr/bin/golangci-lint /usr/bin/
 # Install TFLint #
 ##################
 COPY --from=tflint /usr/local/bin/tflint /usr/bin/
+COPY --from=tflint /root/.tflint.d /root/.tflint.d
 
 #####################
 # Install Terrascan #

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -19,7 +19,7 @@ FROM mstruebing/editorconfig-checker:2.3.5 as editorconfig-checker
 FROM yoheimuta/protolint:v0.32.0 as protolint
 FROM golangci/golangci-lint:v1.41.1 as golangci-lint
 FROM koalaman/shellcheck:v0.7.2 as shellcheck
-FROM wata727/tflint:0.29.1 as tflint
+FROM ghcr.io/terraform-linters/tflint-bundle:v0.30.0 as tflint
 FROM alpine/terragrunt:1.0.1 as terragrunt
 FROM mvdan/shfmt:v3.3.0 as shfmt
 FROM accurics/terrascan:1.8.0 as terrascan
@@ -119,6 +119,7 @@ COPY --from=golangci-lint /usr/bin/golangci-lint /usr/bin/
 # Install TFLint #
 ##################
 COPY --from=tflint /usr/local/bin/tflint /usr/bin/
+COPY --from=tflint /root/.tflint.d /root/.tflint.d
 
 #####################
 # Install Terrascan #

--- a/TEMPLATES/.tflint.hcl
+++ b/TEMPLATES/.tflint.hcl
@@ -4,3 +4,6 @@ config {
   force = false
 }
 
+plugin "aws" {
+  enabled = true
+}


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

This PR switches TFLint image from `wata727/tflint` to `ghcr.io/terraform-linters/tflint-bundle`.

TFLint recently migrated the image registry from Docker Hub to GitHub Container Registry. See https://github.com/terraform-linters/tflint/pull/1155
Images hosted on Docker Hub will no longer be updated.

At the same time, the image to be referenced is changed from `tflint` to `tflint-bundle` here. In the near future, We plan to deprecate the bundled plugin, and if you still need to lint your AWS resources, you'll need to install the plugin with `tflint --init`. See https://github.com/terraform-linters/tflint/pull/1160

The `tflint-bundle` image includes the latest plugins for AWS, Azure, and Google as an option to address this deprecation.
https://github.com/terraform-linters/tflint-bundle

In my understanding, the Super-Linter aims to provide better defaults, and doesn't want to let users choose plugins and run `tflint --init` each time. I believe the `tflint-bundle` image is suitable for the Super-Linter use cases.

## Proposed Changes

1. Switch TFLint image from `wata727/tflint` to `ghcr.io/terraform-linters/tflint-bundle`
2. Add `COPY` instruction to copy pre-installed plugins
3. Add `plugin` declaration to default `.tflint.hcl`. This will only enable the pre-installed AWS plugin

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
