### PR TITLE
feat: support bats

### DIFF
--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -316,6 +316,7 @@ function IsValidShellScript() {
 
   if [ "${FILE_EXTENSION}" == "sh" ] ||
     [ "${FILE_EXTENSION}" == "bash" ] ||
+    [ "${FILE_EXTENSION}" == "bats" ] ||
     [ "${FILE_EXTENSION}" == "dash" ] ||
     [ "${FILE_EXTENSION}" == "ksh" ]; then
     debug "$FILE is a valid shell script (has a valid extension: ${FILE_EXTENSION})"


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->
bats test files are shell scripts executed by bats testing system. It's widely used for testing shell scripts and CLI tools. Can just identify them as shell scripts because all corresponding linters support this format.
## Proposed Changes

1. Support linting of bats files by identifying them as shell scripts (they actually are)

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
