### PR TITLE
Copy TFLint plugins to the final stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -424,6 +424,7 @@ COPY --from=base_image /lib/ /lib/
 COPY --from=base_image /bin/ /bin/
 COPY --from=base_image /node_modules/ /node_modules/
 COPY --from=base_image /home/r-library /home/r-library
+COPY --from=base_image /root/.tflint.d/ /root/.tflint.d/
 COPY --from=clang-format-build /tmp/llvm-project/llvm/build/bin/clang-format /usr/bin/clang-format
 
 ########################################

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -359,6 +359,7 @@ COPY --from=base_image /lib/ /lib/
 COPY --from=base_image /bin/ /bin/
 COPY --from=base_image /node_modules/ /node_modules/
 COPY --from=base_image /home/r-library /home/r-library
+COPY --from=base_image /root/.tflint.d/ /root/.tflint.d/
 COPY --from=clang-format-build /tmp/llvm-project/llvm/build/bin/clang-format /usr/bin/clang-format
 
 ########################################


### PR DESCRIPTION
Follow up of https://github.com/github/super-linter/pull/1777

After checking the release of v4.5.1, I noticed that the changes I made at https://github.com/github/super-linter/pull/1777 are incomplete. The plugins under the home directory copied to `base_image` were not copied to the final stage, and as a result, it seemed that the AWS bundled plugin was used.

```console
$ sudo docker run --rm --entrypoint /bin/bash -it ghcr.io/github/super-linter:slim-v4.5.1
bash-5.1# tflint -c action/lib/.automation/.tflint.hcl -v
TFLint version 0.30.0
+ ruleset.aws (0.5.0-bundled)
```

This change prevents the bundled plugin from being used by copying the plugins to the final stage.

```console
$ sudo docker run --rm --entrypoint /bin/bash -it github/super-linter:slim
bash-5.1# tflint -c action/lib/.automation/.tflint.hcl -v
TFLint version 0.30.0
+ ruleset.aws (0.5.0)
```

## Proposed Changes

1. Add `COPY` instruction to copy the `/root/.tflint.d` to the final stage

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
