### PR TITLE
Use unprivileged user by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -458,11 +458,14 @@ COPY TEMPLATES /action/lib/.automation
 ################################################
 RUN ACTIONS_RUNNER_DEBUG=true WRITE_LINTER_VERSIONS_FILE=true /action/lib/linter.sh
 
+############
+# Set user #
+############
+RUN addgroup -g 1000 superlinter && \
+    adduser -u 1000 -D -G superlinter superlinter
+USER superlinter
+
 ######################
 # Set the entrypoint #
 ######################
 ENTRYPOINT ["/action/lib/linter.sh"]
-
-RUN addgroup -g 1000 superlinter && \
-    adduser -u 1000 -D -G superlinter superlinter
-USER superlinter

--- a/Dockerfile
+++ b/Dockerfile
@@ -462,3 +462,7 @@ RUN ACTIONS_RUNNER_DEBUG=true WRITE_LINTER_VERSIONS_FILE=true /action/lib/linter
 # Set the entrypoint #
 ######################
 ENTRYPOINT ["/action/lib/linter.sh"]
+
+RUN addgroup -g 1000 superlinter && \
+    adduser -u 1000 -D -G superlinter superlinter
+USER superlinter

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -393,11 +393,14 @@ COPY TEMPLATES /action/lib/.automation
 ################################################
 RUN ACTIONS_RUNNER_DEBUG=true WRITE_LINTER_VERSIONS_FILE=true IMAGE=slim /action/lib/linter.sh
 
+############
+# Set user #
+############
+RUN addgroup -g 1000 superlinter && \
+    adduser -u 1000 -D -G superlinter superlinter
+USER superlinter
+
 ######################
 # Set the entrypoint #
 ######################
 ENTRYPOINT ["/action/lib/linter.sh"]
-
-RUN addgroup -g 1000 superlinter && \
-    adduser -u 1000 -D -G superlinter superlinter
-USER superlinter

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -397,3 +397,7 @@ RUN ACTIONS_RUNNER_DEBUG=true WRITE_LINTER_VERSIONS_FILE=true IMAGE=slim /action
 # Set the entrypoint #
 ######################
 ENTRYPOINT ["/action/lib/linter.sh"]
+
+RUN addgroup -g 1000 superlinter && \
+    adduser -u 1000 -D -G superlinter superlinter
+USER superlinter


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #1861.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Add a non-system, unprivileged user to the container images.
2. Set this user as default.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
Since the current behavior hasn't been documented, the change doesn't have to either. It would help little to do document it now, since it is a design detail and immediately obvious when running the container (from the prompt).

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
