### PR TITLE
remove super-linter user due to permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -458,13 +458,6 @@ COPY TEMPLATES /action/lib/.automation
 ################################################
 RUN ACTIONS_RUNNER_DEBUG=true WRITE_LINTER_VERSIONS_FILE=true /action/lib/linter.sh
 
-############
-# Set user #
-############
-RUN addgroup -g 1000 superlinter && \
-    adduser -u 1000 -D -G superlinter superlinter
-USER superlinter
-
 ######################
 # Set the entrypoint #
 ######################

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -393,13 +393,6 @@ COPY TEMPLATES /action/lib/.automation
 ################################################
 RUN ACTIONS_RUNNER_DEBUG=true WRITE_LINTER_VERSIONS_FILE=true IMAGE=slim /action/lib/linter.sh
 
-############
-# Set user #
-############
-RUN addgroup -g 1000 superlinter && \
-    adduser -u 1000 -D -G superlinter superlinter
-USER superlinter
-
 ######################
 # Set the entrypoint #
 ######################


### PR DESCRIPTION
This reverts #1862 

We Have a loy of permission issues once this pushed.
Seems we build out of `/` dir and user has no permissions there....
This needs to be re-done and tested