### PR TITLE
Match AWS States file using "States" JSON key

### DIFF
--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -203,8 +203,8 @@ DetectAWSStatesFIle() {
   ###############################
   # check if file has resources #
   ###############################
-  if grep -q '"Resource": *"arn"*' "${FILE}"; then
-    # Found it
+  if grep -q '"Resource": *"arn' "${FILE}" &&
+     grep -q '"States"' "${FILE}"; then    # Found it
     return 0
   fi
 

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -204,7 +204,7 @@ DetectAWSStatesFIle() {
   # check if file has resources #
   ###############################
   if grep -q '"Resource": *"arn' "${FILE}" &&
-     grep -q '"States"' "${FILE}"; then
+    grep -q '"States"' "${FILE}"; then
     # Found it
     return 0
   fi

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -204,7 +204,8 @@ DetectAWSStatesFIle() {
   # check if file has resources #
   ###############################
   if grep -q '"Resource": *"arn' "${FILE}" &&
-     grep -q '"States"' "${FILE}"; then    # Found it
+     grep -q '"States"' "${FILE}"; then
+    # Found it
     return 0
   fi
 


### PR DESCRIPTION
## Proposed Changes

Matching only on `"Resource": "arn` is too wide and will match also [aws json policy files](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html) for example.
Given the keys States and StartAt are required in any states file it makes sense to use one of them to narrow it down (why not even both...)

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
