### PR TITLE
adding composer code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -399,8 +399,8 @@ RUN wget --tries=5 -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sger
     git git-lfs \
     glibc-${GLIBC_VERSION}.apk \
     gnupg \
-    php7 php7-phar php7-json php7-mbstring php-xmlwriter \
-    php7-tokenizer php7-ctype php7-curl php7-dom php7-simplexml \
+    php7 php7-curl php7-ctype php7-dom php7-iconv php7-json php7-mbstring \
+    php7-openssl php7-phar php7-simplexml php7-tokenizer php-xmlwriter \
     && rm glibc-${GLIBC_VERSION}.apk \
     && wget -q --tries=5 -O /tmp/libz.tar.xz https://www.archlinux.org/packages/core/x86_64/zlib/download \
     && mkdir /tmp/libz \
@@ -436,6 +436,11 @@ COPY --from=base_image /node_modules/ /node_modules/
 COPY --from=base_image /home/r-library /home/r-library
 COPY --from=base_image /root/.tflint.d/ /root/.tflint.d/
 COPY --from=clang-format-build /tmp/llvm-project/llvm/build/bin/clang-format /usr/bin/clang-format
+
+####################################################
+# Install Composer after all Libs have been copied #
+####################################################
+RUN sh -c 'curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer'
 
 ########################################
 # Add node packages to path and dotnet #

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -336,8 +336,8 @@ RUN wget --tries=5 -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sger
     git git-lfs \
     glibc-${GLIBC_VERSION}.apk \
     gnupg \
-    php7 php7-phar php7-json php7-mbstring php-xmlwriter \
-    php7-tokenizer php7-ctype php7-curl php7-dom php7-simplexml \
+    php7 php7-curl php7-ctype php7-dom php7-iconv php7-json php7-mbstring \
+    php7-openssl php7-phar php7-simplexml php7-tokenizer php-xmlwriter \
     && rm glibc-${GLIBC_VERSION}.apk \
     && wget -q --tries=5 -O /tmp/libz.tar.xz https://www.archlinux.org/packages/core/x86_64/zlib/download \
     && mkdir /tmp/libz \
@@ -372,6 +372,11 @@ COPY --from=base_image /node_modules/ /node_modules/
 COPY --from=base_image /home/r-library /home/r-library
 COPY --from=base_image /root/.tflint.d/ /root/.tflint.d/
 COPY --from=clang-format-build /tmp/llvm-project/llvm/build/bin/clang-format /usr/bin/clang-format
+
+####################################################
+# Install Composer after all Libs have been copied #
+####################################################
+RUN sh -c 'curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer'
 
 ########################################
 # Add node packages to path and dotnet #

--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -588,28 +588,6 @@ function BuildFileList() {
       FILE_ARRAY_PHP_PHPSTAN+=("${FILE}")
       FILE_ARRAY_PHP_PSALM+=("${FILE}")
 
-      if [ "${VALIDATE_PHP_PSALM}" == "true" ]; then
-        # found PHP and were validating it, need to composer install
-        info "Found PHP files to validate, and [VALIDATE_PHP_PSALM] set to true, need to run composer install"
-        COMPOSER_CMD=$(composer install 2>&1)
-
-        ##############
-        # Error code #
-        ##############
-        ERROR_CODE=$?
-
-        ##############################
-        # Check the shell for errors #
-        ##############################
-        if [ "${ERROR_CODE}" -ne 0 ]; then
-          # Error
-          error "ERROR! Failed to run composer install"
-          fatal "ERROR:[${COMPOSER_CMD}]"
-        else
-          # Success
-          info "Successfulyl ran;[composer install] for PHP validation"
-        fi
-      fi
     ######################
     # Get the PERL files #
     ######################

--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -588,6 +588,28 @@ function BuildFileList() {
       FILE_ARRAY_PHP_PHPSTAN+=("${FILE}")
       FILE_ARRAY_PHP_PSALM+=("${FILE}")
 
+      if [ "${VALIDATE_PHP_PSALM}" == "true" ]; then
+        # found PHP and were validating it, need to composer install
+        info "Found PHP files to validate, and [VALIDATE_PHP_PSALM] set to true, need to run composer install"
+        COMPOSER_CMD=$(composer install 2>&1)
+
+        ##############
+        # Error code #
+        ##############
+        ERROR_CODE=$?
+
+        ##############################
+        # Check the shell for errors #
+        ##############################
+        if [ "${ERROR_CODE}" -ne 0 ]; then
+          # Error
+          error "ERROR! Failed to run composer install"
+          fatal "ERROR:[${COMPOSER_CMD}]"
+        else
+          # Success
+          info "Successfulyl ran;[composer install] for PHP validation"
+        fi
+      fi
     ######################
     # Get the PERL files #
     ######################

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -394,3 +394,32 @@ function IsGenerated() {
     return 0
   fi
 }
+################################################################################
+#### Function RunAdditionalInstalls ############################################
+function RunAdditionalInstalls() {
+  ##################################
+  # Run installs for Psalm and PHP #
+  ##################################
+  if [ "${VALIDATE_PHP_PSALM}" == "true" ] && [ "${#FILE_ARRAY_PHP_PSALM[@]}" -ne 0 ]; then
+    # found PHP files and were validating it, need to composer install
+    info "Found PHP files to validate, and [VALIDATE_PHP_PSALM] set to true, need to run composer install"
+    COMPOSER_CMD=$(composer install 2>&1)
+
+    ##############
+    # Error code #
+    ##############
+    ERROR_CODE=$?
+
+    ##############################
+    # Check the shell for errors #
+    ##############################
+    if [ "${ERROR_CODE}" -ne 0 ]; then
+      # Error
+      error "ERROR! Failed to run composer install"
+      fatal "ERROR:[${COMPOSER_CMD}]"
+    else
+      # Success
+      info "Successfulyl ran;[composer install] for PHP validation"
+    fi
+  fi
+}

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -403,23 +403,35 @@ function RunAdditionalInstalls() {
   if [ "${VALIDATE_PHP_PSALM}" == "true" ] && [ "${#FILE_ARRAY_PHP_PSALM[@]}" -ne 0 ]; then
     # found PHP files and were validating it, need to composer install
     info "Found PHP files to validate, and [VALIDATE_PHP_PSALM] set to true, need to run composer install"
-    COMPOSER_CMD=$(composer install 2>&1)
+    info "looking for composer.json in the users repository..."
+    mapfile -t COMPOSER_FILE_ARRAY < <(find / -name composer.json 2>&1)
+    debug "COMPOSER_FILE_ARRAY contents: ${COMPOSER_FILE_ARRAY[*]}"
+    ############################################
+    # Check if we found the file in the system #
+    ############################################
+    if [ "${#COMPOSER_FILE_ARRAY[@]}" -ne 0 ]; then
+      for LINE in "${COMPOSER_FILE_ARRAY[@]}"; do
+        PATH=$(dirname "${LINE}" 2>&1)
+        info "Found [composer.json] at:[${LINE}]"
+        COMPOSER_CMD=$(cd "${PATH}" || exit 1; composer install 2>&1)
 
-    ##############
-    # Error code #
-    ##############
-    ERROR_CODE=$?
+        ##############
+        # Error code #
+        ##############
+        ERROR_CODE=$?
 
-    ##############################
-    # Check the shell for errors #
-    ##############################
-    if [ "${ERROR_CODE}" -ne 0 ]; then
-      # Error
-      error "ERROR! Failed to run composer install"
-      fatal "ERROR:[${COMPOSER_CMD}]"
-    else
-      # Success
-      info "Successfulyl ran;[composer install] for PHP validation"
+        ##############################
+        # Check the shell for errors #
+        ##############################
+        if [ "${ERROR_CODE}" -ne 0 ]; then
+          # Error
+          error "ERROR! Failed to run composer install at location:[${PATH}]"
+          fatal "ERROR:[${COMPOSER_CMD}]"
+        else
+          # Success
+          info "Successfully ran:[composer install] for PHP validation"
+        fi
+      done
     fi
   fi
 }

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -413,7 +413,10 @@ function RunAdditionalInstalls() {
       for LINE in "${COMPOSER_FILE_ARRAY[@]}"; do
         PATH=$(dirname "${LINE}" 2>&1)
         info "Found [composer.json] at:[${LINE}]"
-        COMPOSER_CMD=$(cd "${PATH}" || exit 1; composer install 2>&1)
+        COMPOSER_CMD=$(
+          cd "${PATH}" || exit 1
+          composer install 2>&1
+        )
 
         ##############
         # Error code #

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -914,6 +914,11 @@ CheckSSLCert
 ###########################################
 BuildFileList "${VALIDATE_ALL_CODEBASE}" "${TEST_CASE_RUN}" "${ANSIBLE_DIRECTORY}"
 
+#####################################
+# Run additional Installs as needed #
+#####################################
+RunAdditionalInstalls
+
 ###############
 # Run linters #
 ###############


### PR DESCRIPTION
This closes #1920

This will add the loop to run a `composer install` if the variable `VALIDATE_PHP_PSALM` is set to `true` and we find `PHP` code to validate.

This is now added to a new loop to help with additional linters that may need some additional work before a run