### PR TITLE
Correct expressions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy-DEV-slim.yml
+++ b/.github/workflows/deploy-DEV-slim.yml
@@ -30,8 +30,8 @@ jobs:
     # Set the agent to run on
     runs-on: ubuntu-latest
     # Prevent duplicate run from happening when a forked push is committed
-    if: ${{ github.event_name }} == 'push' ||
-        ${{ github.event.pull_request.head.repo.full_name }} != ${{ github.repository }}
+    if: ${{ github.event_name == 'push' }} ||
+        ${{ github.event.pull_request.head.repo.full_name != github.repository }}
     ##################
     # Load all steps #
     ##################

--- a/.github/workflows/deploy-DEV-slim.yml
+++ b/.github/workflows/deploy-DEV-slim.yml
@@ -30,8 +30,8 @@ jobs:
     # Set the agent to run on
     runs-on: ubuntu-latest
     # Prevent duplicate run from happening when a forked push is committed
-    if: ${{ github.event_name == 'push' }} ||
-        ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+    if: ${{ github.event_name == 'push' ||
+            github.event.pull_request.head.repo.full_name != github.repository }}
     ##################
     # Load all steps #
     ##################

--- a/.github/workflows/deploy-DEV-standard.yml
+++ b/.github/workflows/deploy-DEV-standard.yml
@@ -30,8 +30,8 @@ jobs:
     # Set the agent to run on
     runs-on: ubuntu-latest
     # Prevent duplicate run from happening when a forked push is committed
-    if: ${{ github.event_name }} == 'push' ||
-        ${{ github.event.pull_request.head.repo.full_name }} != ${{ github.repository }}
+    if: ${{ github.event_name == 'push' ||
+        ${{ github.event.pull_request.head.repo.full_name != github.repository }}
     ##################
     # Load all steps #
     ##################

--- a/.github/workflows/deploy-DEV-standard.yml
+++ b/.github/workflows/deploy-DEV-standard.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     # Prevent duplicate run from happening when a forked push is committed
     if: ${{ github.event_name == 'push' ||
-        ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+            github.event.pull_request.head.repo.full_name != github.repository }}
     ##################
     # Load all steps #
     ##################

--- a/.github/workflows/deploy-PROD-slim.yml
+++ b/.github/workflows/deploy-PROD-slim.yml
@@ -29,7 +29,7 @@ jobs:
     # Set the agent to run on
     runs-on: ubuntu-latest
     # Only run this on the main repo
-    if: ${{ github.repository }} == 'github/super-linter'
+    if: ${{ github.repository == 'github/super-linter' }}
     ##################
     # Load all steps #
     ##################

--- a/.github/workflows/deploy-PROD-standard.yml
+++ b/.github/workflows/deploy-PROD-standard.yml
@@ -29,7 +29,7 @@ jobs:
     # Set the agent to run on
     runs-on: ubuntu-latest
     # Only run this on the main repo
-    if: ${{ github.repository }} == 'github/super-linter'
+    if: ${{ github.repository == 'github/super-linter' }}
     ##################
     # Load all steps #
     ##################

--- a/.github/workflows/deploy-RELEASE-slim.yml
+++ b/.github/workflows/deploy-RELEASE-slim.yml
@@ -31,10 +31,10 @@ jobs:
     #####################################################################
     # Only run if Admin start job and it was the Release Issue template #
     #####################################################################
-    if: ${{ github.actor }} == 'admiralawkbar' || ${{ github.actor }} == 'jwiebalk' ||
-        ${{ github.actor }} == 'IAmHughes' || ${{ github.actor }} == 'nemchik' ||
-        ${{ github.actor }} == 'Hanse00' || ${{ github.actor }} == 'github-actions' ||
-        ${{ github.actor }} == 'GaboFDC' || ${{ github.actor }} == 'ferrarimarco'
+    if: ${{ github.actor == 'admiralawkbar' || github.actor == 'jwiebalk' ||
+            github.actor == 'IAmHughes' || github.actor == 'nemchik' ||
+            github.actor == 'Hanse00' || github.actor == 'github-actions' ||
+            github.actor == 'GaboFDC' || github.actor == 'ferrarimarco' }}
 
     ##################
     # Load all steps #

--- a/.github/workflows/deploy-RELEASE-standard.yml
+++ b/.github/workflows/deploy-RELEASE-standard.yml
@@ -31,10 +31,10 @@ jobs:
     #####################################################################
     # Only run if Admin start job and it was the Release Issue template #
     #####################################################################
-    if: ${{ github.actor }} == 'admiralawkbar' || ${{ github.actor }} == 'jwiebalk' ||
-        ${{ github.actor }} == 'IAmHughes' || ${{ github.actor }} == 'nemchik' ||
-        ${{ github.actor }} == 'Hanse00' || ${{ github.actor }} == 'github-actions' ||
-        ${{ github.actor }} == 'GaboFDC' || ${{ github.actor }} == 'ferrarimarco'
+    if: ${{ github.actor == 'admiralawkbar' || github.actor == 'jwiebalk' ||
+            github.actor == 'IAmHughes' || github.actor == 'nemchik' ||
+            github.actor == 'Hanse00' || github.actor == 'github-actions' ||
+            github.actor == 'GaboFDC' || github.actor == 'ferrarimarco' }}
 
     ##################
     # Load all steps #

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,7 +26,7 @@ jobs:
   markstale:
     runs-on: ubuntu-latest
     # only run on schedule
-    if: ${{ github.event_name }} == 'schedule'
+    if: ${{ github.event_name == 'schedule' }}
     steps:
       - name: Mark issue stale
         uses: actions/stale@v4
@@ -47,7 +47,7 @@ jobs:
   marknotstale:
     runs-on: ubuntu-latest
     # do not run on schedule
-    if: "${{ github.event_name }} == 'issue_comment' && contains(github.event.issue.labels.*.name, 'O: stale 🤖') && ${{ github.event.issue.user.type }} != 'Bot'"
+    if: "${{ github.event_name == 'issue_comment' }} && contains(github.event.issue.labels.*.name, 'O: stale 🤖') && ${{ github.event.issue.user.type != 'Bot' }}"
     steps:
       - name: Mark issue not stale
         uses: actions/github-script@v4.1


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #1918 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

The expression syntax used by a number of workflows is incorrect.

If you use this syntax:
```yml
if: ${{ github.event_name }} == 'schedule'
```
this will ALWAYS evaluate to true as the evaluation happens in the `${{..}}` part, and the part after the `==` is ignored.

You should instead evaluate the whole expression within the `${{..}}` parts:
```yml
if: ${{ github.event_name == 'schedule' }}
```

Or alternatively the `${{..}}` part is actually optional within `if:` statements so this works too:
```yml
if: github.event_name == 'schedule'
```

This means both parts of the stale job are run (the scheduled part which adds stale label to issue, and also removes it necessary), and the second part (which removes the stale label from the commented on issue only). This means the stale label is attempted to be removed twice, hence why the job fails and you get the email.

I originally noticed this for the stale job after raising #1918 but it actually is wrong in other workflows too, meaning:
- deploys are incorrectly running (and failing) on forks.
- permissions to release are not being checked - I was originally worried when I saw this, but don't _think_ it is really an issue since only maintainers have access to release anyway which is when this workflow is triggered. Still it should be fixed.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

No change to documentation required.

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
