### PR TITLE
Correct Mark Not Stale job - take 2

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -47,7 +47,7 @@ jobs:
   marknotstale:
     runs-on: ubuntu-latest
     # do not run on schedule
-    if: "${{ github.event_name == 'issue_comment' }} && contains(github.event.issue.labels.*.name, 'O: stale 🤖') && ${{ github.event.issue.user.type != 'Bot' }}"
+    if: "${{ github.event_name == 'issue_comment' && contains(github.event.issue.labels.*.name, 'O: stale 🤖') && github.event.issue.user.type != 'Bot' }}"
     steps:
       - name: Mark issue not stale
         uses: actions/github-script@v4.1


### PR DESCRIPTION
Follow on from  #1952

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

I missed one correction when recently fixing your GitHub Action `if:` statements in #1952 so the secodn clear down step is running every night. Still better as not running on every commit and only annoying the maintainers instead of the commentators, but let's fix this one too.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
