### PR TITLE
Improve GITHUB_API_URL default value handling

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -64,10 +64,16 @@ source /action/lib/functions/worker.sh # Source the function script(s)
 ###########
 # GLOBALS #
 ###########
+# GitHub API root url
+if [ ! -z "$GITHUB_CUSTOM_API_URL" ]; then
+  GITHUB_API_URL=$GITHUB_CUSTOM_API_URL
+elif [ -z "$GITHUB_API_URL" ]; then
+  GITHUB_API_URL="https://api.github.com"
+fi
+
 # Default Vars
 DEFAULT_RULES_LOCATION='/action/lib/.automation'                    # Default rules files location
 LINTER_RULES_PATH="${LINTER_RULES_PATH:-.github/linters}"           # Linter rules directory
-GITHUB_API_URL="${GITHUB_CUSTOM_API_URL:-"https://api.github.com"}" # GitHub API root url
 VERSION_FILE='/action/lib/functions/linterVersions.txt'             # File to store linter versions
 export VERSION_FILE                                                 # Workaround SC2034
 


### PR DESCRIPTION
GitHub Actions [already has](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables) `GITHUB_API_URL` environment variable which contains GitHub API URL. We should be smart about overriding it and, if it exist and already has value, we should not override it.

This change allows running the action on GitHub Enterprise without the need to explicitly set `GITHUB_CUSTOM_API_URL`.

## Proposed Changes

1. If `GITHUB_CUSTOM_API_URL` exist, use its value as API URL
2. If `GITHUB_CUSTOM_API_URL` does not exist, but `GITHUB_API_URL` is already set, use its value as API URL
3. If neither `GITHUB_CUSTOM_API_URL` nor `GITHUB_API_URL` is set, use `https://api.github.com` as API URL

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
