### PR TITLE
Fix github scripts to v5

### DIFF
--- a/.github/workflows/deploy-PROD-slim.yml
+++ b/.github/workflows/deploy-PROD-slim.yml
@@ -133,7 +133,7 @@ jobs:
           # https://octokit.github.io/rest.js/v18#issues-create
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const create = await github.issues.create({
+            const create = await github.api.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: "Failed to deploy to production",
@@ -152,7 +152,7 @@ jobs:
           # https://octokit.github.io/rest.js/v18#issues-create
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.issues.addAssignees({
+            github.api.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: "${{ steps.create-issue.outputs.result }}",

--- a/.github/workflows/deploy-PROD-standard.yml
+++ b/.github/workflows/deploy-PROD-standard.yml
@@ -133,7 +133,7 @@ jobs:
           # https://octokit.github.io/rest.js/v18#issues-create
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const create = await github.issues.create({
+            const create = await github.api.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: "Failed to deploy to production",
@@ -152,7 +152,7 @@ jobs:
           # https://octokit.github.io/rest.js/v18#issues-create
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.issues.addAssignees({
+            github.api.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: "${{ steps.create-issue.outputs.result }}",

--- a/.github/workflows/deploy-RELEASE-slim.yml
+++ b/.github/workflows/deploy-RELEASE-slim.yml
@@ -167,7 +167,7 @@ jobs:
           # https://octokit.github.io/rest.js/v18#issues-create
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const create = await github.issues.create({
+            const create = await github.api.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: "Failed to deploy release to production",
@@ -186,7 +186,7 @@ jobs:
           # https://octokit.github.io/rest.js/v18#issues-create
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.issues.addAssignees({
+            github.apiissues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: "${{ steps.create-issue.outputs.result }}",

--- a/.github/workflows/deploy-RELEASE-standard.yml
+++ b/.github/workflows/deploy-RELEASE-standard.yml
@@ -167,7 +167,7 @@ jobs:
           # https://octokit.github.io/rest.js/v18#issues-create
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const create = await github.issues.create({
+            const create = await github.api.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: "Failed to deploy release to production",
@@ -186,7 +186,7 @@ jobs:
           # https://octokit.github.io/rest.js/v18#issues-create
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.issues.addAssignees({
+            github.api.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: "${{ steps.create-issue.outputs.result }}",

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/github-script@v5
         with:
           script: |
-            github.issues.removeLabel({
+            github.rest.issues.removeLabel({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
Updates github-script calls to v5 syntax after dependabot upgraded this in #1996

## Proposed Changes

In v5 of github-script there is [a breaking change](https://github.com/actions/github-script/pull/193) where you need to update `github.issues...` to `github.api.issues...`

At the moment the unstale script is not working for example as noted in https://github.com/github/super-linter/issues/1919#issuecomment-933120578

Also guessing your deploy scripts aren't working properly

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
