### PR TITLE
Fix calling GitHub API (github.api.~ -> github.rest.~)

### DIFF
--- a/.github/workflows/deploy-PROD-slim.yml
+++ b/.github/workflows/deploy-PROD-slim.yml
@@ -133,7 +133,7 @@ jobs:
           # https://octokit.github.io/rest.js/v18#issues-create
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const create = await github.api.issues.create({
+            const create = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: "Failed to deploy to production",
@@ -152,7 +152,7 @@ jobs:
           # https://octokit.github.io/rest.js/v18#issues-create
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.api.issues.addAssignees({
+            github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: "${{ steps.create-issue.outputs.result }}",

--- a/.github/workflows/deploy-PROD-standard.yml
+++ b/.github/workflows/deploy-PROD-standard.yml
@@ -133,7 +133,7 @@ jobs:
           # https://octokit.github.io/rest.js/v18#issues-create
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const create = await github.api.issues.create({
+            const create = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: "Failed to deploy to production",
@@ -152,7 +152,7 @@ jobs:
           # https://octokit.github.io/rest.js/v18#issues-create
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.api.issues.addAssignees({
+            github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: "${{ steps.create-issue.outputs.result }}",

--- a/.github/workflows/deploy-RELEASE-slim.yml
+++ b/.github/workflows/deploy-RELEASE-slim.yml
@@ -167,7 +167,7 @@ jobs:
           # https://octokit.github.io/rest.js/v18#issues-create
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const create = await github.api.issues.create({
+            const create = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: "Failed to deploy release to production",
@@ -186,7 +186,7 @@ jobs:
           # https://octokit.github.io/rest.js/v18#issues-create
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.apiissues.addAssignees({
+            github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: "${{ steps.create-issue.outputs.result }}",

--- a/.github/workflows/deploy-RELEASE-standard.yml
+++ b/.github/workflows/deploy-RELEASE-standard.yml
@@ -167,7 +167,7 @@ jobs:
           # https://octokit.github.io/rest.js/v18#issues-create
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const create = await github.api.issues.create({
+            const create = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: "Failed to deploy release to production",
@@ -186,7 +186,7 @@ jobs:
           # https://octokit.github.io/rest.js/v18#issues-create
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.api.issues.addAssignees({
+            github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: "${{ steps.create-issue.outputs.result }}",


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes
https://github.com/github/super-linter/runs/4169311424?check_suite_focus=true#step:11:27

```
Error: Unhandled error: TypeError: Cannot read property 'issues' of undefined
```

I replace `github.api.~` in the scripts using `actions/github-script@v5` with `github.rest.~` to fix the above error.

https://github.com/actions/github-script#breaking-changes-in-v5
>Version 5 of this action includes the version 5 of `@actions/github` and `@octokit/plugin-rest-endpoint-methods`. As part of this update, the Octokit context available via `github` no longer has REST methods directly. These methods are available via `github.rest.*` - https://github.com/octokit/plugin-rest-endpoint-methods.js/releases/tag/v5.0.0
>
>For example, `github.issues.createComment` in V4 becomes `github.rest.issues.createComment` in V5
## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
