### PR TITLE
Add CI timeout

### DIFF
--- a/.github/workflows/deploy-DEV-slim.yml
+++ b/.github/workflows/deploy-DEV-slim.yml
@@ -32,6 +32,7 @@ jobs:
     # Prevent duplicate run from happening when a forked push is committed
     if: ${{ github.event_name == 'push' ||
             github.event.pull_request.head.repo.full_name != github.repository }}
+    timeout-minutes: 60
     ##################
     # Load all steps #
     ##################

--- a/.github/workflows/deploy-DEV-standard.yml
+++ b/.github/workflows/deploy-DEV-standard.yml
@@ -32,6 +32,7 @@ jobs:
     # Prevent duplicate run from happening when a forked push is committed
     if: ${{ github.event_name == 'push' ||
             github.event.pull_request.head.repo.full_name != github.repository }}
+    timeout-minutes: 60
     ##################
     # Load all steps #
     ##################

--- a/.github/workflows/deploy-PROD-slim.yml
+++ b/.github/workflows/deploy-PROD-slim.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only run this on the main repo
     if: ${{ github.repository == 'github/super-linter' }}
+    timeout-minutes: 60
     ##################
     # Load all steps #
     ##################

--- a/.github/workflows/deploy-PROD-standard.yml
+++ b/.github/workflows/deploy-PROD-standard.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only run this on the main repo
     if: ${{ github.repository == 'github/super-linter' }}
+    timeout-minutes: 60
     ##################
     # Load all steps #
     ##################

--- a/.github/workflows/deploy-RELEASE-slim.yml
+++ b/.github/workflows/deploy-RELEASE-slim.yml
@@ -36,6 +36,8 @@ jobs:
             github.actor == 'Hanse00' || github.actor == 'github-actions' ||
             github.actor == 'GaboFDC' || github.actor == 'ferrarimarco' }}
 
+    timeout-minutes: 60
+
     ##################
     # Load all steps #
     ##################

--- a/.github/workflows/deploy-RELEASE-standard.yml
+++ b/.github/workflows/deploy-RELEASE-standard.yml
@@ -36,6 +36,8 @@ jobs:
             github.actor == 'Hanse00' || github.actor == 'github-actions' ||
             github.actor == 'GaboFDC' || github.actor == 'ferrarimarco' }}
 
+    timeout-minutes: 60
+
     ##################
     # Load all steps #
     ##################

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/stack-linter.yml
+++ b/.github/workflows/stack-linter.yml
@@ -28,6 +28,7 @@ jobs:
     name: Stack linter
     # Set the agent to run on
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     ##################
     # Load all steps #
     ##################

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     # only run on schedule
     if: ${{ github.event_name == 'schedule' }}
+    timeout-minutes: 60
     steps:
       - name: Mark issue stale
         uses: actions/stale@v4
@@ -48,6 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     # do not run on schedule
     if: "${{ github.event_name == 'issue_comment' && contains(github.event.issue.labels.*.name, 'O: stale 🤖') && github.event.issue.user.type != 'Bot' }}"
+    timeout-minutes: 60
     steps:
       - name: Mark issue not stale
         uses: actions/github-script@v5

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -10,6 +10,7 @@ jobs:
   scan-container:
     name: Build
     runs-on: ubuntu-18.04
+    timeout-minutes: 60
     steps:
       ######################
       # Checkout code base #

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -28,6 +28,7 @@ on:
 jobs:
   actions-tagger:
     runs-on: windows-latest
+    timeout-minutes: 60
     steps:
       #############################
       # Check out the latest code #


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes
I set the timeout for each CI to 1 hour because the CI deploying to production may not end.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
