### PR TITLE
Updating docs link in the template

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ name: Lint Code Base
 
 #
 # Documentation:
-# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+# https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
 #
 
 #############################

--- a/TEMPLATES/linter.yml
+++ b/TEMPLATES/linter.yml
@@ -8,7 +8,7 @@ name: Lint Code Base
 
 #
 # Documentation:
-# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+# https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
 #
 
 #############################


### PR DESCRIPTION

## Proposed Changes

1. Updates the documentation link in the template to use `docs.github.com`

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
