### PR TITLE
Fix download and uncompress zlib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -329,15 +329,16 @@ RUN wget --tries=5 -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sger
     ca-certificates \
     git git-lfs \
     glibc-${GLIBC_VERSION}.apk \
+    tar zstd \
     gnupg \
     php7 php7-curl php7-ctype php7-dom php7-iconv php7-json php7-mbstring \
     php7-openssl php7-phar php7-simplexml php7-tokenizer php-xmlwriter \
     && rm glibc-${GLIBC_VERSION}.apk \
-    && wget -q --tries=5 -O /tmp/libz.tar.xz https://www.archlinux.org/packages/core/x86_64/zlib/download \
+    && wget -q --tries=5 -O /tmp/libz.tar.zst https://www.archlinux.org/packages/core/x86_64/zlib/download \
     && mkdir /tmp/libz \
-    && tar -xf /tmp/libz.tar.xz -C /tmp/libz \
+    && tar -xf /tmp/libz.tar.zst -C /tmp/libz --zstd \
     && mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib \
-    && rm -rf /tmp/libz /tmp/libz.tar.xz \
+    && rm -rf /tmp/libz /tmp/libz.tar.zst \
     && wget -q --tries=5 -O phive.phar https://phar.io/releases/phive.phar \
     && wget -q --tries=5 -O phive.phar.asc https://phar.io/releases/phive.phar.asc \
     && PHAR_KEY_ID="0x9D8A98B29B2D5D79" \


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes
Since `zlib` is currently distributed in `tar.zst` format, modify the Dockerfile accordingly.
FYI: https://archive.archlinux.org/packages/z/zlib/

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
