### PR TITLE
Use --strict to report yaml linting warnings

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -943,7 +943,7 @@ LINTER_COMMANDS_ARRAY['TYPESCRIPT_STANDARD']="standard --parser @typescript-esli
 LINTER_COMMANDS_ARRAY['TYPESCRIPT_PRETTIER']="prettier --check"
 LINTER_COMMANDS_ARRAY['UNICODE_CONTROL']="find_unicode_control2.py -c ${UNICODE_CONTROL_LINTER_RULES}"
 LINTER_COMMANDS_ARRAY['XML']="xmllint"
-LINTER_COMMANDS_ARRAY['YAML']="yamllint -c ${YAML_LINTER_RULES} -f parsable"
+LINTER_COMMANDS_ARRAY['YAML']="yamllint --strict -c ${YAML_LINTER_RULES} -f parsable"
 
 debug "--- Linter commands ---"
 debug "-----------------------"


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

Use --strict for yamllint so that warnings are also picked up - as per https://yamllint.readthedocs.io/en/stable/configuration.html#errors-and-warnings we currently get a 0 return code if there are only warnings but no errors, which results in the warnings not being reported. Adding --strict brings the behaviour into line with e.g. xmllint which already returns a non-zero code for warnings only:
```
$ xmllint https://somesite.xml
warning: failed to load external entity "https://somesite.xml"

$ echo $?
1
```

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
