### PR TITLE
Remove .rustup after compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -445,17 +445,18 @@ RUN ln -s /usr/bin/rustup-init /usr/bin/rustup \
     && rustup component add rustfmt --toolchain=stable-x86_64-unknown-linux-musl \
     && rustup component add clippy --toolchain=stable-x86_64-unknown-linux-musl \
     && mv /root/.rustup /usr/lib/.rustup \
-    && ln -fsv /usr/lib/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/rustfmt /usr/bin/rustfmt \
-    && ln -fsv /usr/lib/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/rustc /usr/bin/rustc \
-    && ln -fsv /usr/lib/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/cargo /usr/bin/cargo \
-    && ln -fsv /usr/lib/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/cargo-clippy /usr/bin/cargo-clippy \
+    && cp /usr/lib/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/rustfmt /usr/bin/rustfmt \
+    && cp /usr/lib/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/rustc /usr/bin/rustc \
+    && cp /usr/lib/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/cargo /usr/bin/cargo \
+    && cp /usr/lib/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/cargo-clippy /usr/bin/cargo-clippy \
     && echo '#!/usr/bin/env bash' > /usr/bin/clippy \
     && echo 'pushd $(dirname $1)' >> /usr/bin/clippy \
     && echo 'cargo-clippy' >> /usr/bin/clippy \
     && echo 'rc=$?' >> /usr/bin/clippy \
     && echo 'popd' >> /usr/bin/clippy \
     && echo 'exit $rc' >> /usr/bin/clippy \
-    && chmod +x /usr/bin/clippy
+    && chmod +x /usr/bin/clippy \
+    && rm -rf /usr/lib/.rustup
 
 #########################################
 # Install Powershell + PSScriptAnalyzer #


### PR DESCRIPTION
I profess to not be a rust expert (or having ever used it) but after cargo/clippy/rustfmt are compiled, why do we need to leave the .rustup directory behind, its over 1GB of space and the single largest directory.

This moves the compiled binaries out of `/usr/lib/.rustup` after compilation, and removes the .rustup directory. Whats the effect of removing the .rustup directory

@yanganto it looks like you added Rust, what are the implications of removing the .rustup directory after the binaries have already been built?