### PR TITLE
Pin node dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ RUN pip3 install --no-cache-dir pipenv \
     ####################
     # Run NPM Installs #
     ####################
-    && npm config set package-lock false \
+    && npm config set package-lock true \
     && npm config set loglevel error \
     && npm --no-cache install \
     && npm audit fix --audit-level=critical \

--- a/dependencies/package-lock.json
+++ b/dependencies/package-lock.json
@@ -386,7 +386,7 @@
         "blamer": "^1.0.1",
         "bytes": "^3.1.0",
         "cli-table3": "^0.6.0",
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "fast-glob": "^3.2.2",
         "fs-extra": "^9.0.0",
         "markdown-table": "^2.0.0",
@@ -431,7 +431,7 @@
       "resolved": "https://registry.npmjs.org/@jscpd/html-reporter/-/html-reporter-3.4.1.tgz",
       "integrity": "sha512-2/tIwsCH0jEXxZQQrFyNRfPXldtgiTaj5iUqxByZs40UOK5KQeVyWzB8DTeznrOxDOn4iqMZRX+Rt85oKkQPMg==",
       "dependencies": {
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "fs-extra": "^9.0.1"
       }
     },
@@ -5623,7 +5623,7 @@
         "@jscpd/finder": "^3.4.1",
         "@jscpd/html-reporter": "^3.4.1",
         "@jscpd/tokenizer": "^3.4.1",
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "commander": "^5.0.0",
         "fs-extra": "^9.1.0",
         "gitignore-to-glob": "^0.3.0"
@@ -11122,7 +11122,7 @@
         "blamer": "^1.0.1",
         "bytes": "^3.1.0",
         "cli-table3": "^0.6.0",
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "fast-glob": "^3.2.2",
         "fs-extra": "^9.0.0",
         "markdown-table": "^2.0.0",
@@ -11161,7 +11161,7 @@
       "resolved": "https://registry.npmjs.org/@jscpd/html-reporter/-/html-reporter-3.4.1.tgz",
       "integrity": "sha512-2/tIwsCH0jEXxZQQrFyNRfPXldtgiTaj5iUqxByZs40UOK5KQeVyWzB8DTeznrOxDOn4iqMZRX+Rt85oKkQPMg==",
       "requires": {
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "fs-extra": "^9.0.1"
       },
       "dependencies": {
@@ -15032,7 +15032,7 @@
         "@jscpd/finder": "^3.4.1",
         "@jscpd/html-reporter": "^3.4.1",
         "@jscpd/tokenizer": "^3.4.1",
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "commander": "^5.0.0",
         "fs-extra": "^9.1.0",
         "gitignore-to-glob": "^0.3.0"


### PR DESCRIPTION
The removal of the color.js package broke several of our dependencies.
Enabling package lock and pinning color.js until we can sort out
the color.js dep change.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. ...
2. ...
3. ...

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
