### PR TITLE
adding flag for error on warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ But if you wish to select or exclude specific linters, we give you full control 
 | **VALIDATE_XML**                   | `true`                          | Flag to enable or disable the linting process of the XML language.                                                                                                                                                   |
 | **VALIDATE_YAML**                  | `true`                          | Flag to enable or disable the linting process of the YAML language.                                                                                                                                                  |
 | **YAML_CONFIG_FILE**               | `.yaml-lint.yml`                | Filename for [Yamllint configuration](https://yamllint.readthedocs.io/en/stable/configuration.html) (ex: `.yaml-lint.yml`, `.yamllint.yml`)                                                                          |
+| **YAML_ERROR_ON_WARNING**          | `false`                         | Flag to enable or disable the error on warning for Yamllint.                                                                                                                                                         |
 
 ### Template rules files
 

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -943,7 +943,7 @@ LINTER_COMMANDS_ARRAY['TYPESCRIPT_ES']="eslint --no-eslintrc -c ${TYPESCRIPT_ES_
 LINTER_COMMANDS_ARRAY['TYPESCRIPT_STANDARD']="standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin ${TYPESCRIPT_STANDARD_LINTER_RULES}"
 LINTER_COMMANDS_ARRAY['TYPESCRIPT_PRETTIER']="prettier --check"
 LINTER_COMMANDS_ARRAY['XML']="xmllint"
-if [ -n "${YAML_ERROR_ON_WARNING}" == 'false' ]; then
+if [ "${YAML_ERROR_ON_WARNING}" == 'false' ]; then
   LINTER_COMMANDS_ARRAY['YAML']="yamllint -c ${YAML_LINTER_RULES} -f parsable"
 else
   LINTER_COMMANDS_ARRAY['YAML']="yamllint --strict -c ${YAML_LINTER_RULES} -f parsable"

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -193,6 +193,8 @@ TYPESCRIPT_STANDARD_FILE_NAME="${TYPESCRIPT_ES_CONFIG_FILE:-.eslintrc.yml}"
 USE_FIND_ALGORITHM="${USE_FIND_ALGORITHM:-false}"
 # shellcheck disable=SC2034  # Variable is referenced indirectly
 YAML_FILE_NAME="${YAML_CONFIG_FILE:-.yaml-lint.yml}"
+# shellcheck disable=SC2034  # Variable is referenced indirectly
+YAML_ERROR_ON_WARNING="${YAML_ERROR_ON_WARNING:-false}"
 
 #################################################
 # Parse if we are using JS standard or prettier #
@@ -941,7 +943,11 @@ LINTER_COMMANDS_ARRAY['TYPESCRIPT_ES']="eslint --no-eslintrc -c ${TYPESCRIPT_ES_
 LINTER_COMMANDS_ARRAY['TYPESCRIPT_STANDARD']="standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin ${TYPESCRIPT_STANDARD_LINTER_RULES}"
 LINTER_COMMANDS_ARRAY['TYPESCRIPT_PRETTIER']="prettier --check"
 LINTER_COMMANDS_ARRAY['XML']="xmllint"
-LINTER_COMMANDS_ARRAY['YAML']="yamllint --strict -c ${YAML_LINTER_RULES} -f parsable"
+if [ -n "${YAML_ERROR_ON_WARNING}" == 'false' ]; then
+  LINTER_COMMANDS_ARRAY['YAML']="yamllint -c ${YAML_LINTER_RULES} -f parsable"
+else
+  LINTER_COMMANDS_ARRAY['YAML']="yamllint --strict -c ${YAML_LINTER_RULES} -f parsable"
+fi
 
 debug "--- Linter commands ---"
 debug "-----------------------"


### PR DESCRIPTION
This closes #2396 

Added the flag `YAML_ERROR_ON_WARNING` that defaults to `false`
This will remove the `--strict` that causes errors on warnings
Setting the flag to `true` will enable the `--strict` flag