### PR TITLE
adding lind command output to success

### DIFF
--- a/lib/functions/worker.sh
+++ b/lib/functions/worker.sh
@@ -309,6 +309,7 @@ function LintCodebase() {
           # Success #
           ###########
           info " - File:${F[W]}[${FILE_NAME}]${F[B]} was linted with ${F[W]}[${LINTER_NAME}]${F[B]} successfully"
+          info "   - Command output:${NC}\n------\n${LINT_CMD}\n------"
         fi
       else
         #######################################


### PR DESCRIPTION
This is an interesting addition...

This would now start showing the output of all linter commands on success...

It has come to the attention that some linters, such as yamllint, show warnings, but users may never be aware of them as its masked by the `0` return code and never printed.

Most outputs seem to have no real output but a `0` return code.
Some such as `GitLeaks` have returns like:
![Screen Shot 2022-01-27 at 3 21 35 PM](https://user-images.githubusercontent.com/29484535/151445712-24ff4a76-7154-4fae-817c-bdd6dacd785b.png)

So this would cause some additional lines in the output log...

@lindluni @zkoppert @nemchik @Hanse00 @GaboFDC @ferrarimarco
Does anyone have any for or against this small but likely impactful fix?