### PR TITLE
fix: tflint should clean up after itself

### DIFF
--- a/lib/functions/worker.sh
+++ b/lib/functions/worker.sh
@@ -28,6 +28,11 @@ function LintCodebase() {
   ##########################
   LIST_FILES=()
 
+  ###################################################
+  # Array to track directories where tflint was run #
+  ###################################################
+  declare -A TFLINT_SEEN_DIRS
+
   ################
   # Set the flag #
   ################
@@ -261,15 +266,30 @@ function LintCodebase() {
       # Corner case for TERRAFORM_TFLINT as it cant use the full path and needs to fetch modules #
       ############################################################################################
       elif [[ ${FILE_TYPE} == "TERRAFORM_TFLINT" ]]; then
+        # Check the cache to see if we've already prepped this directory for tflint
+        if [[ ! -v "TFLINT_SEEN_DIRS[${DIR_NAME}]" ]]; then
+          debug "  Setting up TERRAFORM_TFLINT cache for ${DIR_NAME}"
+
+          TF_DOT_DIR="${DIR_NAME}/.terraform"
+          if [ -d "${TF_DOT_DIR}" ]; then
+            # Just in case there's something in the .terraform folder, keep a copy of it
+            TF_BACKUP_DIR="/tmp/.terraform-tflint-backup${DIR_NAME}"
+            debug "  Backing up ${TF_DOT_DIR} to ${TF_BACKUP_DIR}"
+
+            mkdir -p "${TF_BACKUP_DIR}"
+            cp -r "${TF_DOT_DIR}" "${TF_BACKUP_DIR}"
+            # Store the destination directory so we can restore from our copy later
+            TFLINT_SEEN_DIRS[${DIR_NAME}]="${TF_BACKUP_DIR}"
+          else
+            # Just let the cache know we've seen this before
+            TFLINT_SEEN_DIRS[${DIR_NAME}]='false'
+          fi
+
+          terraform get 2>&1
+        fi
+
         LINT_CMD=$(
           cd "${DIR_NAME}" || exit
-          # Just in case there's something in the .terraform folder, keep a copy of it
-          [ -d '.terraform' ] && cp -r .terraform /tmp/.terraform-tflint-backup
-          terraform get 2>&1
-          # Clean up after ourselves
-          rm -rf .terraform
-          # Put the copy back in place
-          [ -d '/tmp/.terraform-tflint-backup' ] && mv /tmp/.terraform-tflint-backup .terraform
           ${LINTER_COMMAND} "${FILE_NAME}" 2>&1
         )
       else
@@ -343,6 +363,22 @@ function LintCodebase() {
       debug "Error code: ${ERROR_CODE}. Command output:${NC}\n------\n${LINT_CMD}\n------"
     done
   fi
+
+  # Clean up after TFLINT
+  for TF_DIR in "${!TFLINT_SEEN_DIRS[@]}"; do
+    (
+      cd "${TF_DIR}" || exit
+      rm -rf .terraform
+
+      # Check to see if there was a .terraform folder there before we got started, restore it if so
+      POTENTIAL_BACKUP_DIR="${TFLINT_SEEN_DIRS[${TF_DIR}]}"
+      if [[ "${POTENTIAL_BACKUP_DIR}" != 'false' ]]; then
+        # Put the copy back in place
+        debug "  Restoring ${TF_DIR}/.terraform from ${POTENTIAL_BACKUP_DIR}"
+        mv "${POTENTIAL_BACKUP_DIR}/.terraform" .terraform
+      fi
+    )
+  done
 
   ##############################
   # Validate we ran some tests #

--- a/lib/functions/worker.sh
+++ b/lib/functions/worker.sh
@@ -263,7 +263,13 @@ function LintCodebase() {
       elif [[ ${FILE_TYPE} == "TERRAFORM_TFLINT" ]]; then
         LINT_CMD=$(
           cd "${DIR_NAME}" || exit
+          # Just in case there's something in the .terraform folder, keep a copy of it
+          [ -d '.terraform' ] && cp -r .terraform /tmp/.terraform-tflint-backup
           terraform get 2>&1
+          # Clean up after ourselves
+          rm -rf .terraform
+          # Put the copy back in place
+          [ -d '/tmp/.terraform-tflint-backup' ] && mv /tmp/.terraform-tflint-backup .terraform
           ${LINTER_COMMAND} "${FILE_NAME}" 2>&1
         )
       else


### PR DESCRIPTION
<!-- markdownlint-disable -->

Fixes #2433

<!-- markdownlint-restore -->

Restores or cleans up the `.terraform` folder after `tflint` runs.

This adds a caching layer to the `TERRAFORM_TFLINT` worker that keeps track of the first time a directory was seen. If an existing `.terraform` folder is that directory, then that folder will be saved to `/tmp` and restored after the `TERRAFORM_TFLINT` worker finishes. If there is no `.terraform` folder, then the `.terraform` folder that was created during linting is simply removed. This should unblock workflows that either:

* Expect no `.terraform` folder to be created by Super Linter
* Expect their existing `.terraform` folder to stay the same after Super Linter is run

This should support all the same workflows that existed before `terraform get` was added in https://github.com/github/super-linter/pull/2297

NOTE: The caching layer does add some complexity, but is meant to deal with the edge case where someone may have many `.tf` files in a particular directory. The cache allows Super Linter to only run `terraform get` a single time per directory. Without the cache, `terraform get` would be run once for every since file in a directory, potentially causing significant runtime increases for users with many `.tf` files.

## Proposed Changes

1. `tflint` cleans up after itself, restoring the `.terraform` folder to its previous state. If there was no `.terraform` folder before Super Linter ran, no `.terraform` folder will exist after it runs.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
