### PR TITLE
fix: don't check the $GITHUB_TOKEN if multi-status is disabled

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -563,7 +563,7 @@ GetGitHubVars() {
   ############################
   # Validate we have a value #
   ############################
-  if [ -z "${GITHUB_TOKEN}" ] && [[ ${RUN_LOCAL} == "false" ]]; then
+  if [ "${MULTI_STATUS}" == "true" ] && [ -z "${GITHUB_TOKEN}" ] && [[ ${RUN_LOCAL} == "false" ]]; then
     error "Failed to get [GITHUB_TOKEN]!"
     error "[${GITHUB_TOKEN}]"
     error "Please set a [GITHUB_TOKEN] from the main workflow environment to take advantage of multiple status reports!"


### PR DESCRIPTION
<!-- Describe what the changes are -->

## Proposed Changes

Since the $GITHUB_TOKEN is required only for the multi-status feature to
work, avoid printing an error in case the feature is explicitly
disabled and we don't pass $GITHUB_TOKEN to Super-Linter.

i.e. don't print:

```
2022-02-13 14:24:13 [ERROR]   Failed to get [GITHUB_TOKEN]!
2022-02-13 14:24:13 [ERROR]   []
2022-02-13 14:24:13 [ERROR]   Please set a [GITHUB_TOKEN] from the main workflow environment to take advantage of multiple status reports!
```

when `MULTI_STATUS=false`.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
