### PR TITLE
Echo output only when necessary

### DIFF
--- a/lib/functions/worker.sh
+++ b/lib/functions/worker.sh
@@ -338,7 +338,9 @@ function LintCodebase() {
           # Success #
           ###########
           info " - File:${F[W]}[${FILE_NAME}]${F[B]} was linted with ${F[W]}[${LINTER_NAME}]${F[B]} successfully"
-          info "   - Command output:${NC}\n------\n${LINT_CMD}\n------"
+          if [ -n "${LINT_CMD}" ]; then
+            info "   - Command output:${NC}\n------\n${LINT_CMD}\n------"
+          fi
         fi
       else
         #######################################


### PR DESCRIPTION
## Proposed Changes

Echo the output only if `LINT_CMD` length is greater than `0`. This saves some output. Example:

```
2022-02-23 19:31:16 [INFO]      - Command output:
------

------
```

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
