### PR TITLE
Copy over Python headers during staged build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -371,6 +371,7 @@ COPY --from=base_image /usr/bin/ /usr/bin/
 COPY --from=base_image /usr/local/bin/ /usr/local/bin/
 COPY --from=base_image /usr/local/lib/ /usr/local/lib/
 COPY --from=base_image /usr/local/share/ /usr/local/share/
+COPY --from=base_image /usr/local/include/ /usr/local/include/
 COPY --from=base_image /usr/lib/ /usr/lib/
 COPY --from=base_image /usr/share/ /usr/share/
 COPY --from=base_image /usr/include/ /usr/include/


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

- I am using the Mypy type checker as part of the super linter. Mypy requires type information for packages imported by my code. For some packages it can get these by installing type stubs, which super linter supports nicely (https://github.com/github/super-linter/pull/1937), but for other packages such as Numpy and Scipy, the package itself needs to be installed. 

- I would like to be able to run `pip install numpy` inside the container, but sadly this fails, because the Python headers are missing from the container.

- One commenter https://github.com/github/super-linter/issues/157#issuecomment-648850330 suggests some ideas for how to bind external packages into the super linter, but unfortunately that will not work for Mypy, which does not check `PYTHONPATH` or other environment variables for external directories containing packages. Instead, everything needs to be installed directly into the virtual environment from which Mypy is run. Proposals to change this have not yet been merged, see for example https://github.com/python/mypy/issues/5701.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Copy over the Python headers in `/usr/local/include` from the base image during the container build. This will add approximately one megabyte to the container size.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
