### PR TITLE
Check for kind when detecting Kubernetes files

### DIFF
--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -181,9 +181,9 @@ DetectKubernetesFile() {
   ################
   FILE="${1}" # File that we need to validate
   debug "Checking if ${FILE} is a Kubernetes descriptor..."
-  if grep -q -v 'kustomize.config.k8s.io' "${FILE}" && \
-    grep -q -v "tekton" "${FILE}" && \
-    grep -q -E '(apiVersion):' "${FILE}" && \
+  if grep -q -v 'kustomize.config.k8s.io' "${FILE}" &&
+    grep -q -v "tekton" "${FILE}" &&
+    grep -q -E '(apiVersion):' "${FILE}" &&
     grep -q -E '(kind):' "${FILE}"; then
     debug "${FILE} is a Kubernetes descriptor"
     return 0

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -181,10 +181,10 @@ DetectKubernetesFile() {
   ################
   FILE="${1}" # File that we need to validate
   debug "Checking if ${FILE} is a Kubernetes descriptor..."
-  if grep -q -v 'kustomize.config.k8s.io' "${FILE}" \
-    && grep -v "tekton" "${FILE}" \
-    && grep -E '(apiVersion):' "${FILE}" \
-    && grep -q -E '(kind):' "${FILE}"; then
+  if grep -q -v 'kustomize.config.k8s.io' "${FILE}" && \
+    grep -q -v "tekton" "${FILE}" && \
+    grep -q -E '(apiVersion):' "${FILE}" && \
+    grep -q -E '(kind):' "${FILE}"; then
     debug "${FILE} is a Kubernetes descriptor"
     return 0
   fi

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -182,7 +182,7 @@ DetectKubernetesFile() {
   FILE="${1}" # File that we need to validate
   debug "Checking if ${FILE} is a Kubernetes descriptor..."
 
-  if grep -v 'kustomize.config.k8s.io' "${FILE}" | grep -v tekton | grep -q -E '(apiVersion):' | grep -q -E '(kind):'; then
+  if grep -v 'kustomize.config.k8s.io' "${FILE}" | grep -v tekton | grep -E '(apiVersion):' | grep -q -E '(kind):'; then
     debug "${FILE} is a Kubernetes descriptor"
     return 0
   fi

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -181,8 +181,10 @@ DetectKubernetesFile() {
   ################
   FILE="${1}" # File that we need to validate
   debug "Checking if ${FILE} is a Kubernetes descriptor..."
-
-  if grep -v 'kustomize.config.k8s.io' "${FILE}" | grep -v tekton | grep -E '(apiVersion):' | grep -q -E '(kind):'; then
+  if grep -q -v 'kustomize.config.k8s.io' "${FILE}" \
+    && grep -v "tekton" "${FILE}" \
+    && grep -E '(apiVersion):' "${FILE}" \
+    && grep -q -E '(kind):' "${FILE}"; then
     debug "${FILE} is a Kubernetes descriptor"
     return 0
   fi

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -182,7 +182,7 @@ DetectKubernetesFile() {
   FILE="${1}" # File that we need to validate
   debug "Checking if ${FILE} is a Kubernetes descriptor..."
 
-  if grep -v 'kustomize.config.k8s.io' "${FILE}" | grep -v tekton | grep -q -E '(apiVersion):'; then
+  if grep -v 'kustomize.config.k8s.io' "${FILE}" | grep -v tekton | grep -q -E '(apiVersion):' | grep -q -E '(kind):'; then
     debug "${FILE} is a Kubernetes descriptor"
     return 0
   fi


### PR DESCRIPTION
## Proposed Changes

1. Check for the presence of the `kind` key when detecting Kubernetes files to avoid including Grafana configuration files that also use the `apiVersion` key.
2. Refactor the checks in `DetectKubernetesFile` so each check analyzes the whole file content instead of the output of the previous check. This is needed because a check might strip down content making it impossible "chain" checks.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
