### PR TITLE
Don't override the PATH when installing Psalm

### DIFF
--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -418,10 +418,10 @@ function RunAdditionalInstalls() {
     ############################################
     if [ "${#COMPOSER_FILE_ARRAY[@]}" -ne 0 ]; then
       for LINE in "${COMPOSER_FILE_ARRAY[@]}"; do
-        PATH=$(dirname "${LINE}" 2>&1)
+        COMPOSER_PATH=$(dirname "${LINE}" 2>&1)
         info "Found [composer.json] at:[${LINE}]"
         COMPOSER_CMD=$(
-          cd "${PATH}" || exit 1
+          cd "${COMPOSER_PATH}" || exit 1
           composer install --no-progress -q 2>&1
         )
 
@@ -435,7 +435,7 @@ function RunAdditionalInstalls() {
         ##############################
         if [ "${ERROR_CODE}" -ne 0 ]; then
           # Error
-          error "ERROR! Failed to run composer install at location:[${PATH}]"
+          error "ERROR! Failed to run composer install at location:[${COMPOSER_PATH}]"
           fatal "ERROR:[${COMPOSER_CMD}]"
         else
           # Success


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #2432
Fixes #2005

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Change the name of the variable that holds the composer file path from `PATH` to `COMPOSER_PATH` to avoid overwriting the `PATH` and messing with the environment.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
