### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -18,8 +18,14 @@ on:
 #################
 # Start the job #
 #################
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
+    permissions:
+      contents: write  # for release-drafter/release-drafter to create a github release
+      pull-requests: write  # for release-drafter/release-drafter to add label to PR
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/repo-visualization.yml
+++ b/.github/workflows/repo-visualization.yml
@@ -22,6 +22,9 @@ on:
 ###############
 # Set the Job #
 ###############
+permissions:
+  contents: read
+
 jobs:
   build:
     # Name the Job

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,6 +24,9 @@ jobs:
   # Mark an Issue Stale #
   #######################
   markstale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     # only run on schedule
     if: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -6,8 +6,14 @@ on:
     branches:
       - main
   pull_request:
+permissions:
+  contents: read
+
 jobs:
   scan-container:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     name: Build
     runs-on: ubuntu-18.04
     timeout-minutes: 60

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -25,8 +25,13 @@ on:
 #################
 # Start the job #
 #################
+permissions:
+  contents: read
+
 jobs:
   actions-tagger:
+    permissions:
+      contents: write  # for Actions-R-Us/actions-tagger to create a release and add latest tag
     runs-on: windows-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
