### PR TITLE
SQLFluff 0.12.0 upgrade

### DIFF
--- a/.automation/test/sqlfluff/.sqlfluff
+++ b/.automation/test/sqlfluff/.sqlfluff
@@ -1,0 +1,2 @@
+[sqlfluff]
+dialect = ansi

--- a/.automation/test/sqlfluff/README.md
+++ b/.automation/test/sqlfluff/README.md
@@ -4,7 +4,9 @@ This folder holds the test cases for **SQL**.
 
 ## Additional Docs
 
-No Additional information is needed for this test case.
+From version 0.12.0 SQLFluff requires a dialect to be set, and no longer sets a default. This can be provided as a command line argument, or a `.sqlfluff` config file (either in the usualy place for SQLFluff config files, or within the folder containg the SQL).
+
+For SQLFluff we have added a default `.sqlfluff` config file in this test directory.
 
 ## Good Test Cases
 

--- a/.github/linters/.sqlfluff
+++ b/.github/linters/.sqlfluff
@@ -1,4 +1,4 @@
-## This .sqlfluffini file can be used to configure the SQLFluff linter when
+## This /.sqlfluff file can be used to configure the SQLFluff linter when
 ## used via the GitHub Super Linter. Copy it to the .github/linters folder of
 ## your repo, and uncomment the necessary lines to configure the Super Linter.
 ##
@@ -31,7 +31,11 @@
 #output_line_length = 80
 ## Number of passes to run before admitting defeat
 #runaway_limit = 10
-## Ignore linting errors in templated sections
+## Ignore errors by category (one or more of the following, separated by commas: lexing,linting,parsing,templating)
+#ignore = None
+## Ignore linting errors found within sections of code coming directly from
+## templated code (e.g. from within Jinja curly braces. Note that it does not
+## ignore errors from literal code found within template loops.
 #ignore_templated_areas = True
 ## can either be autodetect or a valid encoding e.g. utf-8, utf-8-sig
 #encoding = autodetect
@@ -40,27 +44,23 @@
 ## Comma separated list of file extensions to lint
 ## NB: This config will only apply in the root folder
 #sql_file_exts = .sql,.sql.j2,.dml,.ddl
-#
+## Allow fix to run on files, even if they contain parsing errors
+## Note altering this is NOT RECOMMENDED as can corrupt SQL
+#fix_even_unparsable = False
+
 [sqlfluff:indentation]
 ## See https://docs.sqlfluff.com/en/stable/indentation.html
 #indented_joins = False
+#indented_ctes = False
 #indented_using_on = True
 #template_blocks_indent = True
-#
+
 [sqlfluff:templater]
 #unwrap_wrapped_queries = True
-#
+
 [sqlfluff:templater:jinja]
 #apply_dbt_builtins = True
-#
-[sqlfluff:templater:jinja:macros]
-## Macros provided as builtins for dbt projects
-#dbt_ref = {% macro ref(model_ref) %}{{model_ref}}{% endmacro %}
-#dbt_source = {% macro source(source_name, table) %}{{source_name}}_{{table}}{% endmacro %}
-#dbt_config = {% macro config() %}{% for k in kwargs %}{% endfor %}{% endmacro %}
-#dbt_var = {% macro var(variable, default='') %}item{% endmacro %}
-#dbt_is_incremental = {% macro is_incremental() %}True{% endmacro %}
-#
+
 ## Some rules can be configured directly from the config common to other rules
 [sqlfluff:rules]
 #tab_space_size = 4
@@ -70,79 +70,117 @@
 #allow_scalar = True
 #single_table_references = consistent
 #unquoted_identifiers_policy = all
-#
+
 ## Some rules have their own specific config
 [sqlfluff:rules:L007]
 #operator_new_lines = after
-#
+
 [sqlfluff:rules:L010]
 ## Keywords
 #capitalisation_policy = consistent
-#
+## Comma separated list of words to ignore for this rule
+#ignore_words = None
+
 [sqlfluff:rules:L011]
 ## Aliasing preference for tables
 #aliasing = explicit
-#
+
 [sqlfluff:rules:L012]
 ## Aliasing preference for columns
 #aliasing = explicit
-#
+
 [sqlfluff:rules:L014]
 ## Unquoted identifiers
 #extended_capitalisation_policy = consistent
-#
+## Comma separated list of words to ignore for this rule
+#ignore_words = None
+
 [sqlfluff:rules:L016]
 ## Line length
 #ignore_comment_lines = False
-#
+#ignore_comment_clauses = False
+
 [sqlfluff:rules:L026]
 ## References must be in FROM clause
 ## Disabled for some dialects (e.g. bigquery)
 #force_enable = False
-#
+
 [sqlfluff:rules:L028]
 ## References must be consistently used
 ## Disabled for some dialects (e.g. bigquery)
 #force_enable = False
-#
+
 [sqlfluff:rules:L029]
 ## Keywords should not be used as identifiers.
 #unquoted_identifiers_policy = aliases
 #quoted_identifiers_policy = none
-#
+## Comma separated list of words to ignore for this rule
+#ignore_words = None
+
 [sqlfluff:rules:L030]
 ## Function names
-#capitalisation_policy = consistent
-#
+#extended_capitalisation_policy = consistent
+## Comma separated list of words to ignore for this rule
+#ignore_words = None
+
+[sqlfluff:rules:L031]
+## Avoid table aliases in from clauses and join conditions.
+## Disabled for some dialects (e.g. bigquery)
+#force_enable = False
+
 [sqlfluff:rules:L038]
 ## Trailing commas
 #select_clause_trailing_comma = forbid
-#
+
 [sqlfluff:rules:L040]
 ## Null & Boolean Literals
 #capitalisation_policy = consistent
-#
+## Comma separated list of words to ignore for this rule
+#ignore_words = None
+
 [sqlfluff:rules:L042]
 ## By default, allow subqueries in from clauses, but not join clauses
 #forbid_subquery_in = join
-#
+
 [sqlfluff:rules:L047]
 ## Consistent syntax to count all rows
 #prefer_count_1 = False
 #prefer_count_0 = False
-#
+
+[sqlfluff:rules:L051]
+## Fully qualify JOIN clause
+#fully_qualify_join_types = inner
+
 [sqlfluff:rules:L052]
 ## Semi-colon formatting approach
 #multiline_newline = False
 #require_final_semicolon = False
-#
+
 [sqlfluff:rules:L054]
 ## GROUP BY/ORDER BY column references
 #group_by_and_order_by_style = consistent
-#
+
 [sqlfluff:rules:L057]
 ## Special characters in identifiers
 #unquoted_identifiers_policy = all
 #quoted_identifiers_policy = all
 #allow_space_in_identifier = False
 #additional_allowed_characters = ""
+## Comma separated list of words to ignore for this rule
+#ignore_words = None
+
+[sqlfluff:rules:L059]
+## Policy on quoted and unquoted identifiers
+#prefer_quoted_identifiers = False
+## Comma separated list of words to ignore for this rule
+#ignore_words = None
+
+[sqlfluff:rules:L062]
+## Comma separated list of blocked words that should not be used
+#blocked_words = None
+
+[sqlfluff:rules:L063]
+## Data Types
+#extended_capitalisation_policy = consistent
+## Comma separated list of words to ignore for this rule
+#ignore_words = None

--- a/TEMPLATES/.sqlfluff
+++ b/TEMPLATES/.sqlfluff
@@ -31,7 +31,11 @@
 #output_line_length = 80
 ## Number of passes to run before admitting defeat
 #runaway_limit = 10
-## Ignore linting errors in templated sections
+## Ignore errors by category (one or more of the following, separated by commas: lexing,linting,parsing,templating)
+#ignore = None
+## Ignore linting errors found within sections of code coming directly from
+## templated code (e.g. from within Jinja curly braces. Note that it does not
+## ignore errors from literal code found within template loops.
 #ignore_templated_areas = True
 ## can either be autodetect or a valid encoding e.g. utf-8, utf-8-sig
 #encoding = autodetect
@@ -40,27 +44,23 @@
 ## Comma separated list of file extensions to lint
 ## NB: This config will only apply in the root folder
 #sql_file_exts = .sql,.sql.j2,.dml,.ddl
-#
+## Allow fix to run on files, even if they contain parsing errors
+## Note altering this is NOT RECOMMENDED as can corrupt SQL
+#fix_even_unparsable = False
+
 [sqlfluff:indentation]
 ## See https://docs.sqlfluff.com/en/stable/indentation.html
 #indented_joins = False
+#indented_ctes = False
 #indented_using_on = True
 #template_blocks_indent = True
-#
+
 [sqlfluff:templater]
 #unwrap_wrapped_queries = True
-#
+
 [sqlfluff:templater:jinja]
 #apply_dbt_builtins = True
-#
-[sqlfluff:templater:jinja:macros]
-## Macros provided as builtins for dbt projects
-#dbt_ref = {% macro ref(model_ref) %}{{model_ref}}{% endmacro %}
-#dbt_source = {% macro source(source_name, table) %}{{source_name}}_{{table}}{% endmacro %}
-#dbt_config = {% macro config() %}{% for k in kwargs %}{% endfor %}{% endmacro %}
-#dbt_var = {% macro var(variable, default='') %}item{% endmacro %}
-#dbt_is_incremental = {% macro is_incremental() %}True{% endmacro %}
-#
+
 ## Some rules can be configured directly from the config common to other rules
 [sqlfluff:rules]
 #tab_space_size = 4
@@ -70,79 +70,117 @@
 #allow_scalar = True
 #single_table_references = consistent
 #unquoted_identifiers_policy = all
-#
+
 ## Some rules have their own specific config
 [sqlfluff:rules:L007]
 #operator_new_lines = after
-#
+
 [sqlfluff:rules:L010]
 ## Keywords
 #capitalisation_policy = consistent
-#
+## Comma separated list of words to ignore for this rule
+#ignore_words = None
+
 [sqlfluff:rules:L011]
 ## Aliasing preference for tables
 #aliasing = explicit
-#
+
 [sqlfluff:rules:L012]
 ## Aliasing preference for columns
 #aliasing = explicit
-#
+
 [sqlfluff:rules:L014]
 ## Unquoted identifiers
 #extended_capitalisation_policy = consistent
-#
+## Comma separated list of words to ignore for this rule
+#ignore_words = None
+
 [sqlfluff:rules:L016]
 ## Line length
 #ignore_comment_lines = False
-#
+#ignore_comment_clauses = False
+
 [sqlfluff:rules:L026]
 ## References must be in FROM clause
 ## Disabled for some dialects (e.g. bigquery)
 #force_enable = False
-#
+
 [sqlfluff:rules:L028]
 ## References must be consistently used
 ## Disabled for some dialects (e.g. bigquery)
 #force_enable = False
-#
+
 [sqlfluff:rules:L029]
 ## Keywords should not be used as identifiers.
 #unquoted_identifiers_policy = aliases
 #quoted_identifiers_policy = none
-#
+## Comma separated list of words to ignore for this rule
+#ignore_words = None
+
 [sqlfluff:rules:L030]
 ## Function names
-#capitalisation_policy = consistent
-#
+#extended_capitalisation_policy = consistent
+## Comma separated list of words to ignore for this rule
+#ignore_words = None
+
+[sqlfluff:rules:L031]
+## Avoid table aliases in from clauses and join conditions.
+## Disabled for some dialects (e.g. bigquery)
+#force_enable = False
+
 [sqlfluff:rules:L038]
 ## Trailing commas
 #select_clause_trailing_comma = forbid
-#
+
 [sqlfluff:rules:L040]
 ## Null & Boolean Literals
 #capitalisation_policy = consistent
-#
+## Comma separated list of words to ignore for this rule
+#ignore_words = None
+
 [sqlfluff:rules:L042]
 ## By default, allow subqueries in from clauses, but not join clauses
 #forbid_subquery_in = join
-#
+
 [sqlfluff:rules:L047]
 ## Consistent syntax to count all rows
 #prefer_count_1 = False
 #prefer_count_0 = False
-#
+
+[sqlfluff:rules:L051]
+## Fully qualify JOIN clause
+#fully_qualify_join_types = inner
+
 [sqlfluff:rules:L052]
 ## Semi-colon formatting approach
 #multiline_newline = False
 #require_final_semicolon = False
-#
+
 [sqlfluff:rules:L054]
 ## GROUP BY/ORDER BY column references
 #group_by_and_order_by_style = consistent
-#
+
 [sqlfluff:rules:L057]
 ## Special characters in identifiers
 #unquoted_identifiers_policy = all
 #quoted_identifiers_policy = all
 #allow_space_in_identifier = False
 #additional_allowed_characters = ""
+## Comma separated list of words to ignore for this rule
+#ignore_words = None
+
+[sqlfluff:rules:L059]
+## Policy on quoted and unquoted identifiers
+#prefer_quoted_identifiers = False
+## Comma separated list of words to ignore for this rule
+#ignore_words = None
+
+[sqlfluff:rules:L062]
+## Comma separated list of blocked words that should not be used
+#blocked_words = None
+
+[sqlfluff:rules:L063]
+## Data Types
+#extended_capitalisation_policy = consistent
+## Comma separated list of words to ignore for this rule
+#ignore_words = None

--- a/dependencies/python/sqlfluff.txt
+++ b/dependencies/python/sqlfluff.txt
@@ -16,7 +16,7 @@ pyparsing==3.0.8
 pytest==7.1.1
 PyYAML==6.0
 regex==2022.3.15
-sqlfluff==0.11.2
+sqlfluff==0.12.0
 tblib==1.7.0
 toml==0.10.2
 tomli==2.0.1


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #2785 
Supersedes #2779

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

SQLFluff 0.12.0 now requires a dialect to be set and no longer provides a default

This change:

1. Sets a default .sqlfluff config file in the `.automation/test/sqlfluff/` folder so tests can pass.
2. Updates the README in that folder to explain this
3. Updates the example config file to the latest set of options available (unrelated to above, but it was a bit out of date so included that in here).

Note Super Linter users who use SQLFluff will similarly need to configure SQLFluff now, after this upgrade is rolled out. The reasons for this breaking change are given in #2785 

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
