### PR TITLE
chore: 🤖 stylelint support less & prettier

### DIFF
--- a/dependencies/package-lock.json
+++ b/dependencies/package-lock.json
@@ -34,12 +34,14 @@
         "markdownlint-cli": "^0.31.1",
         "node-fetch": "^3.2.3",
         "npm-groovy-lint": "^9.4.1",
+        "postcss-less": "^6.0.0",
         "prettier": "^2.6.1",
         "prettyjson": "^1.2.5",
         "pug": "^3.0.2",
         "sql-lint": "0.0.19",
         "standard": "^16.0.4",
         "stylelint": "^14.6.1",
+        "stylelint-config-prettier": "^9.0.3",
         "stylelint-config-recommended-scss": "^6.0.0",
         "stylelint-config-sass-guidelines": "^9.0.1",
         "stylelint-config-standard": "^25.0.0",
@@ -7264,6 +7266,17 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-less": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-6.0.0.tgz",
+      "integrity": "sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.5"
+      }
+    },
     "node_modules/postcss-media-query-parser": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
@@ -8975,6 +8988,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/stylelint"
+      }
+    },
+    "node_modules/stylelint-config-prettier": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.3.tgz",
+      "integrity": "sha512-5n9gUDp/n5tTMCq1GLqSpA30w2sqWITSSEiAWQlpxkKGAUbjcemQ0nbkRvRUa0B1LgD3+hCvdL7B1eTxy1QHJg==",
+      "bin": {
+        "stylelint-config-prettier": "bin/check.js",
+        "stylelint-config-prettier-check": "bin/check.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "stylelint": ">=11.0.0"
       }
     },
     "node_modules/stylelint-config-recommended": {
@@ -15978,6 +16006,12 @@
         "source-map-js": "^1.0.2"
       }
     },
+    "postcss-less": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-6.0.0.tgz",
+      "integrity": "sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==",
+      "requires": {}
+    },
     "postcss-media-query-parser": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
@@ -17262,6 +17296,12 @@
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
         }
       }
+    },
+    "stylelint-config-prettier": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.3.tgz",
+      "integrity": "sha512-5n9gUDp/n5tTMCq1GLqSpA30w2sqWITSSEiAWQlpxkKGAUbjcemQ0nbkRvRUa0B1LgD3+hCvdL7B1eTxy1QHJg==",
+      "requires": {}
     },
     "stylelint-config-recommended": {
       "version": "6.0.0",

--- a/dependencies/package.json
+++ b/dependencies/package.json
@@ -39,6 +39,8 @@
     "stylelint-config-sass-guidelines": "^9.0.1",
     "stylelint-config-standard": "^25.0.0",
     "stylelint-config-standard-scss": "^3.0.0",
+    "stylelint-config-prettier": "^9.0.3",
+    "postcss-less": "^6.0.0",
     "stylelint-scss": "^4.2.0",
     "tekton-lint": "^0.6.0",
     "textlint": "^12.1.1",


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. stylelint support postcss-less. 
2. stylelint support prettier.
3. ...

I found that stylelint don't support less & prettier yet.  It only support css standard, scss, scss standard.

Styleint have suggest prettier for css and postcss-less for less in the [GET START](https://stylelint.io/user-guide/get-started) of stylelint.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
