### PR TITLE
Disable flake8 rule E203

### DIFF
--- a/.automation/test/python_black/python_bad_1.py
+++ b/.automation/test/python_black/python_bad_1.py
@@ -12,7 +12,7 @@ api_url = getenv(API_URL, default='https://api.github.com/graphql' )
 github_token = getenv("GITHUB_TOKEN",
 default=None)
 m = [1, 2, 3]
-print(m[1:2])
+print(m[1:])
 
 if github_token is None
     sys.exit("GitHub Token is not set." +

--- a/.automation/test/python_black/python_bad_1.py
+++ b/.automation/test/python_black/python_bad_1.py
@@ -11,6 +11,8 @@ env = load_dotenv()
 api_url = getenv(API_URL, default='https://api.github.com/graphql' )
 github_token = getenv("GITHUB_TOKEN",
 default=None)
+m = [1, 2, 3]
+print(m[1:2])
 
 if github_token is None
     sys.exit("GitHub Token is not set." +

--- a/.automation/test/python_black/python_bad_1.py
+++ b/.automation/test/python_black/python_bad_1.py
@@ -12,7 +12,7 @@ api_url = getenv(API_URL, default='https://api.github.com/graphql' )
 github_token = getenv("GITHUB_TOKEN",
 default=None)
 m = [1, 2, 3]
-print(m[len('t'):])
+print(m[len("t"):])
 
 if github_token is None
     sys.exit("GitHub Token is not set." +

--- a/.automation/test/python_black/python_bad_1.py
+++ b/.automation/test/python_black/python_bad_1.py
@@ -12,7 +12,7 @@ api_url = getenv(API_URL, default='https://api.github.com/graphql' )
 github_token = getenv("GITHUB_TOKEN",
 default=None)
 m = [1, 2, 3]
-print(m[1:])
+print(m[len('t'):])
 
 if github_token is None
     sys.exit("GitHub Token is not set." +

--- a/.automation/test/python_black/python_good_1.py
+++ b/.automation/test/python_black/python_good_1.py
@@ -11,7 +11,7 @@ env = load_dotenv()
 api_url = getenv("API_URL", default="https://api.github.com/graphql")
 github_token = getenv("GITHUB_TOKEN", default=None)
 m = [1, 2, 3]
-print(m[1 : 2])
+print(m[1 :])
 
 if github_token is None:
     sys.exit(

--- a/.automation/test/python_black/python_good_1.py
+++ b/.automation/test/python_black/python_good_1.py
@@ -11,7 +11,7 @@ env = load_dotenv()
 api_url = getenv("API_URL", default="https://api.github.com/graphql")
 github_token = getenv("GITHUB_TOKEN", default=None)
 m = [1, 2, 3]
-print(m[1 :])
+print(m[len('t') :])
 
 if github_token is None:
     sys.exit(

--- a/.automation/test/python_black/python_good_1.py
+++ b/.automation/test/python_black/python_good_1.py
@@ -11,7 +11,7 @@ env = load_dotenv()
 api_url = getenv("API_URL", default="https://api.github.com/graphql")
 github_token = getenv("GITHUB_TOKEN", default=None)
 m = [1, 2, 3]
-print(m[len('t') :])
+print(m[len("t") :])
 
 if github_token is None:
     sys.exit(

--- a/.automation/test/python_black/python_good_1.py
+++ b/.automation/test/python_black/python_good_1.py
@@ -10,6 +10,8 @@ from dotenv import load_dotenv  # pylint: disable=import-error
 env = load_dotenv()
 api_url = getenv("API_URL", default="https://api.github.com/graphql")
 github_token = getenv("GITHUB_TOKEN", default=None)
+m = [1, 2, 3]
+print(m[1 : 2])
 
 if github_token is None:
     sys.exit(

--- a/.automation/test/python_flake8/python_good_1.py
+++ b/.automation/test/python_flake8/python_good_1.py
@@ -11,7 +11,7 @@ env = load_dotenv()
 api_url = getenv("API_URL", default="https://api.github.com/graphql")
 github_token = getenv("GITHUB_TOKEN", default=None)
 m = [1, 2, 3]
-print(m[1 : 2])
+print(m[1 :])
 
 if github_token is None:
     sys.exit(

--- a/.automation/test/python_flake8/python_good_1.py
+++ b/.automation/test/python_flake8/python_good_1.py
@@ -11,7 +11,7 @@ env = load_dotenv()
 api_url = getenv("API_URL", default="https://api.github.com/graphql")
 github_token = getenv("GITHUB_TOKEN", default=None)
 m = [1, 2, 3]
-print(m[1 :])
+print(m[len('t') :])
 
 if github_token is None:
     sys.exit(

--- a/.automation/test/python_flake8/python_good_1.py
+++ b/.automation/test/python_flake8/python_good_1.py
@@ -11,7 +11,7 @@ env = load_dotenv()
 api_url = getenv("API_URL", default="https://api.github.com/graphql")
 github_token = getenv("GITHUB_TOKEN", default=None)
 m = [1, 2, 3]
-print(m[len('t') :])
+print(m[len("t") :])
 
 if github_token is None:
     sys.exit(

--- a/.automation/test/python_flake8/python_good_1.py
+++ b/.automation/test/python_flake8/python_good_1.py
@@ -10,6 +10,8 @@ from dotenv import load_dotenv  # pylint: disable=import-error
 env = load_dotenv()
 api_url = getenv("API_URL", default="https://api.github.com/graphql")
 github_token = getenv("GITHUB_TOKEN", default=None)
+m = [1, 2, 3]
+print(m[1 : 2])
 
 if github_token is None:
     sys.exit(

--- a/.github/linters/.flake8
+++ b/.github/linters/.flake8
@@ -1,2 +1,3 @@
 [flake8]
+ignore = E203
 max-line-length = 120

--- a/.github/linters/.flake8
+++ b/.github/linters/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E203,W503
 max-line-length = 120
+extend-ignore = E203

--- a/.github/linters/.flake8
+++ b/.github/linters/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E203
+ignore = E203,W503
 max-line-length = 120

--- a/TEMPLATES/.flake8
+++ b/TEMPLATES/.flake8
@@ -1,2 +1,3 @@
 [flake8]
+ignore = E203
 max-line-length = 120

--- a/TEMPLATES/.flake8
+++ b/TEMPLATES/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E203,W503
 max-line-length = 120
+extend-ignore = E203

--- a/TEMPLATES/.flake8
+++ b/TEMPLATES/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E203
+ignore = E203,W503
 max-line-length = 120


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #2757

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

I disable `flake8` rule `E203` because this rule conflicts with `black`.
FYI: https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
