### PR TITLE
Bump textlint-rule-terminology from 2.1.5 to 3.0.0 in /dependencies

### DIFF
--- a/dependencies/package-lock.json
+++ b/dependencies/package-lock.json
@@ -51,7 +51,7 @@
         "textlint": "^12.1.1",
         "textlint-filter-rule-allowlist": "^4.0.0",
         "textlint-filter-rule-comments": "^1.2.2",
-        "textlint-rule-terminology": "^2.1.5",
+        "textlint-rule-terminology": "^3.0.0",
         "ts-standard": "^11.0.0",
         "typescript": "^4.6.3"
       }
@@ -9461,16 +9461,16 @@
       }
     },
     "node_modules/textlint-rule-terminology": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/textlint-rule-terminology/-/textlint-rule-terminology-2.1.5.tgz",
-      "integrity": "sha512-VW+ea4ByLPddSUqoFkVVJF8zWnO8kqKwvC681wGFAjI4CYz9WhjEQH1ikhoEHXnd5AFXNArcjyoa8hoihrXy0w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-terminology/-/textlint-rule-terminology-3.0.0.tgz",
+      "integrity": "sha512-ySHbdLcA9Mdbbbc/Wkts3f8CVvY2Nsy3r21NH4bK785jhdpZozG771WDR7d7L5nNnFBeH7MmS0IcscfMpxMyvQ==",
       "dependencies": {
         "lodash": "^4.17.15",
         "strip-json-comments": "^3.0.1",
         "textlint-rule-helper": "^2.1.1"
       },
       "engines": {
-        "node": ">=8.9"
+        "node": ">=14"
       }
     },
     "node_modules/textlint/node_modules/file-entry-cache": {
@@ -17987,9 +17987,9 @@
       }
     },
     "textlint-rule-terminology": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/textlint-rule-terminology/-/textlint-rule-terminology-2.1.5.tgz",
-      "integrity": "sha512-VW+ea4ByLPddSUqoFkVVJF8zWnO8kqKwvC681wGFAjI4CYz9WhjEQH1ikhoEHXnd5AFXNArcjyoa8hoihrXy0w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-terminology/-/textlint-rule-terminology-3.0.0.tgz",
+      "integrity": "sha512-ySHbdLcA9Mdbbbc/Wkts3f8CVvY2Nsy3r21NH4bK785jhdpZozG771WDR7d7L5nNnFBeH7MmS0IcscfMpxMyvQ==",
       "requires": {
         "lodash": "^4.17.15",
         "strip-json-comments": "^3.0.1",

--- a/dependencies/package.json
+++ b/dependencies/package.json
@@ -46,7 +46,7 @@
     "textlint": "^12.1.1",
     "textlint-filter-rule-allowlist": "^4.0.0",
     "textlint-filter-rule-comments": "^1.2.2",
-    "textlint-rule-terminology": "^2.1.5",
+    "textlint-rule-terminology": "^3.0.0",
     "ts-standard": "^11.0.0",
     "typescript": "^4.6.3"
   }


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->

<!-- Describe what the changes are -->

## Proposed Changes

Updates NPM dependency `textlint-rule-terminology` to the latest version.

### Reviewing Maintainer

- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
