### PR TITLE
Remove lockfile when updating deps

### DIFF
--- a/.github/scripts/update-npm.sh
+++ b/.github/scripts/update-npm.sh
@@ -11,6 +11,8 @@ echo "Installing NPM dependencies..."
 npm install
 echo "Updating NPM dependencies..."
 ncu -u
+echo "Removing existing lockfile..."
+rm -rf package-lock.json
 echo "Installing NPM dependencies..."
 npm install
 


### PR DESCRIPTION
The existence of the current lockfile can prevent some es-lint dependencies from being updating. Doing a hard remove at first ensures we don't hit the inability to resolve dependencies when auto-updating.