### PR TITLE
Update pylint disable rules to include import-error

### DIFF
--- a/TEMPLATES/.python-lint
+++ b/TEMPLATES/.python-lint
@@ -62,6 +62,7 @@ disable=raw-checker-failed,
         suppressed-message,
         useless-suppression,
         deprecated-pragma,
+        import-error
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
Adds back import-error to the pylint disable rules that was accidentally removed in #3038 

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #3180 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Ignore `pylint` import errors for python files

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request (N/A)

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
