### PR TITLE
Remove npm-groovy-lint custom handling as it now accepts files as arguments

### DIFF
--- a/lib/functions/worker.sh
+++ b/lib/functions/worker.sh
@@ -215,17 +215,6 @@ function LintCodebase() {
           exit $? 2>&1
         )
       ###############################################################################
-      # Corner case for groovy as we have to pass it as path and file in ant format #
-      ###############################################################################
-      elif [[ ${FILE_TYPE} == "GROOVY" ]]; then
-        #######################################
-        # Lint the file with the updated path #
-        #######################################
-        LINT_CMD=$(
-          cd "${WORKSPACE_PATH}" || exit
-          ${LINTER_COMMAND} --path "${DIR_NAME}" --files "$FILE_NAME" 2>&1
-        )
-      ###############################################################################
       # Corner case for R as we have to pass it to R                                #
       ###############################################################################
       elif [[ ${FILE_TYPE} == "R" ]]; then


### PR DESCRIPTION
npm-groovy-lint now accepts a list of files as arguments (and provides better performances)

To custom handling adding -path and -files is now useless so has been removed