### PR TITLE
Stop logging token 

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -355,7 +355,6 @@ DEFAULT_BRANCH="${DEFAULT_BRANCH:-master}" # Default Git Branch to use (master b
 # GITHUB_REPOSITORY="${GITHUB_REPOSITORY}"         # GitHub Org/Repo passed from system
 # GITHUB_RUN_ID="${GITHUB_RUN_ID}"                 # GitHub RUn ID to point to logs
 # GITHUB_SHA="${GITHUB_SHA}"                       # GitHub sha from the commit
-# GITHUB_TOKEN="${GITHUB_TOKEN}"                   # GitHub Token passed from environment
 # GITHUB_WORKSPACE="${GITHUB_WORKSPACE}"           # Github Workspace
 # TEST_CASE_RUN="${TEST_CASE_RUN}"                 # Boolean to validate only test cases
 # VALIDATE_ALL_CODEBASE="${VALIDATE_ALL_CODEBASE}" # Boolean to validate all files


### PR DESCRIPTION
Registering the token in the log has no value, if a user pulls the token from the secret store it is automatically redacted, moreover the python scripts that drive Super Linter exit if the token is not set.

The risk is in users registering tokens by other means, such as generating app tokens at runtime where they can't be registered as secrets. Since there is all risk and no reward, remove the logging of the token. 