### PR TITLE
Add `rubocop-minitest` and `minitest-rake`

### DIFF
--- a/dependencies/Gemfile
+++ b/dependencies/Gemfile
@@ -6,6 +6,8 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem "rubocop", "~> 1.35.0"
 gem "rubocop-github", "~> 0.18.0"
+gem "rubocop-minitest", "~> 0.21.0"
 gem "rubocop-performance", "~>1.14.3"
 gem "rubocop-rails", "~> 2.15"
+gem "rubocop-rake", "~> 0.6.0"
 gem "rubocop-rspec", "~> 2.12.1"

--- a/dependencies/Gemfile.lock
+++ b/dependencies/Gemfile.lock
@@ -35,6 +35,8 @@ GEM
       rubocop (>= 1.0.0)
       rubocop-performance
       rubocop-rails
+    rubocop-minitest (0.21.0)
+      rubocop (>= 0.90, < 2.0)
     rubocop-performance (1.14.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -42,6 +44,8 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
     rubocop-rspec (2.12.1)
       rubocop (~> 1.31)
     ruby-progressbar (1.11.0)
@@ -55,9 +59,11 @@ PLATFORMS
 DEPENDENCIES
   rubocop (~> 1.35.0)
   rubocop-github (~> 0.18.0)
+  rubocop-minitest (~> 0.21.0)
   rubocop-performance (~> 1.14.3)
   rubocop-rails (~> 2.15)
+  rubocop-rake (~> 0.6.0)
   rubocop-rspec (~> 2.12.1)
 
 BUNDLED WITH
-  2.3.5
+   2.3.5

--- a/dependencies/Gemfile.lock
+++ b/dependencies/Gemfile.lock
@@ -66,4 +66,4 @@ DEPENDENCIES
   rubocop-rspec (~> 2.12.1)
 
 BUNDLED WITH
-   2.3.5
+  2.3.5


### PR DESCRIPTION
They are both official and recommended by RuboCop itself.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Add `rubocop-minitest` and `minitest-rake`

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
