### PR TITLE
Add source variables from env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Example usage:
 
 ## Environment variables
 
-The super-linter allows you to pass the following `ENV` variables to be able to trigger different functionality.
+The super-linter allows you to pass the following `ENV` variables to be able to trigger different functionality. You can also specify environment variables in .github/super-linter.env which will be used by both a local super-linter run and from Github actions.
 
 _Note:_ All the `VALIDATE_[LANGUAGE]` variables behave in a very specific way:
 

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -21,6 +21,14 @@ IMAGE="${IMAGE:-standard}"                            # Version of the Super-lin
 LOG_FILE="${LOG_FILE:-super-linter.log}" # Default log file name (located in GITHUB_WORKSPACE folder)
 LOG_LEVEL="${LOG_LEVEL:-VERBOSE}"        # Default log level (VERBOSE, DEBUG, TRACE)
 
+##################################################################
+# Get Environment Variables from env file                        #
+##################################################################
+SUPER_LINTER_ENV_FILE="${SUPER_LINTER_ENV_FILE:-.github/super-linter.env}" # Default env file name
+if test -f "$SUPER_LINTER_ENV_FILE"; then
+  source SUPER_LINTER_ENV_FILE
+fi
+
 if [[ ${ACTIONS_RUNNER_DEBUG} == true ]]; then LOG_LEVEL="DEBUG"; fi
 # Boolean to see trace logs
 LOG_TRACE=$(if [[ ${LOG_LEVEL} == "TRACE" ]]; then echo "true"; fi)


### PR DESCRIPTION
This allows to stop requiring duplication of most env variables if you
use something like STRTA - for example:
[test script](https://github.com/azavea/echo-locator/blob/273f543ca734c813c16cda8f3750fcf35f6356a3/scripts/test#L41)
and [ci build](https://github.com/azavea/echo-locator/blob/273f543ca734c813c16cda8f3750fcf35f6356a3/.github/workflows/ci.yml#L43)

Instead you can just put the shared env variables in .github/super-linter.env and super-linter will pull from there by
default (can also override).

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #2851

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Add check for and sourcing env file 

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
