### PR TITLE
Build process improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,3 +28,8 @@ spaces_around_brackets = false
 [{Makefile,go.mod,go.sum,*.go,.gitmodules}]
 indent_style = tab
 indent_size = 4
+
+[**/test/*.{kt,kts}]
+# Disable the filename rule because our test case logic requires that files used in test cases
+# follow a certain syntax which is not compatible with what ktlint currently mandates (PascalCase)
+disabled_rules = filename

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,8 @@ RUN apk add --no-cache \
     openssh-client \
     openssl-dev \
     perl perl-dev \
-    py3-setuptools python3-dev \
+    py3-setuptools python3-dev  \
+    py3-pyflakes \
     R R-dev R-doc \
     readline-dev \
     ruby ruby-dev ruby-bundler ruby-rdoc \
@@ -108,15 +109,7 @@ RUN npm config set package-lock true  \
 ##############################
 # Installs Perl dependencies #
 ##############################
-RUN curl --retry 5 --retry-delay 5 -sL https://cpanmin.us/ | perl - -nq --no-wget Perl::Critic Perl::Critic::Community \
-    #######################
-    # Installs ActionLint #
-    #######################
-    && curl --retry 5 --retry-delay 5 -sLO https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash \
-    && chmod +x download-actionlint.bash \
-    && ./download-actionlint.bash \
-    && rm download-actionlint.bash \
-    && mv actionlint /usr/bin/actionlint
+RUN curl --retry 5 --retry-delay 5 -sL https://cpanmin.us/ | perl - -nq --no-wget Perl::Critic Perl::Critic::Community
 
 ######################
 # Install shellcheck #

--- a/dependencies/package-lock.json
+++ b/dependencies/package-lock.json
@@ -12,7 +12,7 @@
         "@stoplight/spectral": "^6.1.0",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
-        "asl-validator": "^2.2.1",
+        "asl-validator": "^3.0.8",
         "axios": "^0.27.2",
         "babel-eslint": "^10.1.0",
         "eslint": "^7.32.0",
@@ -2530,9 +2530,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
-      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -2735,38 +2735,35 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
-    "node_modules/asl-validator": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-2.2.1.tgz",
-      "integrity": "sha512-GzG/vY94kbyGVm9Pw+oZPPZC74Aw4RVBOp0NXXCsS04KkiNS54LaZDlPUiWuKkHmmTWgWvJUlYnn1ztnE2cT7A==",
+    "node_modules/asl-path-validator": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.11.0.tgz",
+      "integrity": "sha512-2kfFkqNCXInc7d8hbUoXn/XpK5fFr3//0nh4jfcZWav0VR4zo2bYVlRCwOuNKJID9yM4vIo7dMb4n0fnWrc/Xw==",
       "dependencies": {
-        "ajv": "^6.12.6",
+        "jsonpath-plus": "^7.0.0"
+      }
+    },
+    "node_modules/asl-path-validator/node_modules/jsonpath-plus": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
+      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/asl-validator": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-3.0.8.tgz",
+      "integrity": "sha512-ku2hkt137ebImA6DNySVoBtymffl/62TQHWKBb54yI3twrcsQyi78fPtvRi+PMob89vLeb0BbGezr5+4rQcJ7Q==",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "asl-path-validator": "^0.11.0",
         "commander": "^5.1.0",
         "jsonpath-plus": "^7.0.0"
       },
       "bin": {
-        "asl-validator": "bin/asl-validator.js"
+        "asl-validator": "dist/bin/asl-validator.js"
       }
-    },
-    "node_modules/asl-validator/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/asl-validator/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/asl-validator/node_modules/jsonpath-plus": {
       "version": "7.0.0",
@@ -13429,9 +13426,9 @@
       }
     },
     "ajv": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
-      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -13570,32 +13567,32 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
-    "asl-validator": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-2.2.1.tgz",
-      "integrity": "sha512-GzG/vY94kbyGVm9Pw+oZPPZC74Aw4RVBOp0NXXCsS04KkiNS54LaZDlPUiWuKkHmmTWgWvJUlYnn1ztnE2cT7A==",
+    "asl-path-validator": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.11.0.tgz",
+      "integrity": "sha512-2kfFkqNCXInc7d8hbUoXn/XpK5fFr3//0nh4jfcZWav0VR4zo2bYVlRCwOuNKJID9yM4vIo7dMb4n0fnWrc/Xw==",
       "requires": {
-        "ajv": "^6.12.6",
+        "jsonpath-plus": "^7.0.0"
+      },
+      "dependencies": {
+        "jsonpath-plus": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
+          "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA=="
+        }
+      }
+    },
+    "asl-validator": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-3.0.8.tgz",
+      "integrity": "sha512-ku2hkt137ebImA6DNySVoBtymffl/62TQHWKBb54yI3twrcsQyi78fPtvRi+PMob89vLeb0BbGezr5+4rQcJ7Q==",
+      "requires": {
+        "ajv": "^8.11.0",
+        "asl-path-validator": "^0.11.0",
         "commander": "^5.1.0",
         "jsonpath-plus": "^7.0.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
         "jsonpath-plus": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.0.0.tgz",

--- a/dependencies/package.json
+++ b/dependencies/package.json
@@ -5,7 +5,7 @@
     "@stoplight/spectral": "^6.1.0",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
-    "asl-validator": "^2.2.1",
+    "asl-validator": "^3.0.8",
     "axios": "^0.27.2",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.32.0",

--- a/lib/functions/linterVersions.sh
+++ b/lib/functions/linterVersions.sh
@@ -72,7 +72,7 @@ BuildLinterVersions() {
       if [[ ${LINTER} == "arm-ttk" ]]; then
         # Need specific command for ARM
         GET_VERSION_CMD="$(grep -iE 'version' "/usr/bin/arm-ttk" | xargs 2>&1)"
-      elif [[ ${LINTER} == "bash-exec" ]] || [[ ${LINTER} == "gherkin-lint" ]]; then
+      elif [[ ${LINTER} == "bash-exec" ]] || [[ ${LINTER} == "gherkin-lint" ]] || [[ ${LINTER} == "asl-validator" ]]; then
         # Need specific command for Protolint and editorconfig-checker
         GET_VERSION_CMD="$(echo "--version not supported")"
       elif [[ ${LINTER} == "lintr" ]]; then

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -653,7 +653,7 @@ CallStatusAPI() {
     # Call the status API to create status check #
     ##############################################
     SEND_STATUS_CMD=$(
-      curl -f -s -X POST \
+      curl -f -s --show-error -X POST \
         --url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
         -H 'accept: application/vnd.github.v3+json' \
         -H "authorization: Bearer ${GITHUB_TOKEN}" \

--- a/test/inspec/inspec.lock
+++ b/test/inspec/inspec.lock
@@ -1,3 +1,0 @@
----
-lockfile_version: 1
-depends: []

--- a/test/inspec/super-linter/controls/super_linter.rb
+++ b/test/inspec/super-linter/controls/super_linter.rb
@@ -94,7 +94,7 @@ control "super-linter-installed-commands" do
     { linter_name: "actionlint"},
     { linter_name: "ansible-lint"},
     { linter_name: "arm-ttk", version_command: "grep -iE 'version' '/usr/bin/arm-ttk' | xargs"},
-    { linter_name: "asl-validator"},
+    { linter_name: "asl-validator", expected_exit_status: 1}, # expect a return code = 1 because this linter doesn't support a "get linter version" command
     { linter_name: "bash-exec", expected_exit_status: 1}, # expect a return code = 1 because this linter doesn't support a "get linter version" command
     { linter_name: "black"},
     { linter_name: "clang-format"},

--- a/test/inspec/super-linter/controls/super_linter.rb
+++ b/test/inspec/super-linter/controls/super_linter.rb
@@ -13,6 +13,7 @@ control "super-linter-installed-packages" do
 
   packages = [
     "bash",
+    "ca-certificates",
     "coreutils",
     "curl",
     "gcc",
@@ -43,6 +44,7 @@ control "super-linter-installed-packages" do
     "openssl-dev",
     "perl-dev",
     "perl",
+    "py3-pyflakes",
     "py3-setuptools",
     "python3-dev",
     "rakudo",
@@ -392,7 +394,7 @@ control "super-linter-validate-files" do
     "/action/lib/.automation/.scalafmt.conf",
     "/action/lib/.automation/.snakefmt.toml",
     "/action/lib/.automation/.sql-config.json",
-    "/action/lib/.automation//.sqlfluff",
+    "/action/lib/.automation/.sqlfluff",
     "/action/lib/.automation/.stylelintrc.json",
     "/action/lib/.automation/.tflint.hcl",
     "/action/lib/.automation/.yaml-lint.yml",


### PR DESCRIPTION
## Proposed Changes

1. Don't install `actionlint` using the installation script because we already do that by copying it from its container image.
2. Install the `py3-pyflakes` package (+ relevant test) because it's needed by `actionlint`.
3. Added a missing test to verify that we install the `ca-certificates` package.
4. Fix a typo in the `.sqlfluff` file path in the InSpec test control.
5. Cherry-picked the version check for `asl-validator` from #3298
6. Configured ktlint to not expect test cases files to require PascalCase naming so that we don't have to change our test logic.
7. Update `asl-validator` to `3.0.8` by merging with #3310. This ensures that the fix we cherry-picked works and that we can update `asl-validator`. Otherwise, we're stuck in a chicken-and-egg problem. Dependabot will take care of closing #3310 after we merge this one.
8. Show errors when using curl to call the status API, otherwise we can't show anything if that call fails. Useful to investigate #3137.
9. Make the build more reproducible by explicitly setting versions for checkstyle, google-java-format, and ktlint. This should also make the build more robust by not requiring additional calls to the GitHub APIs to get the `latest` release download URL.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
