### PR TITLE
Disable YAML linting in ansible-lint

### DIFF
--- a/TEMPLATES/.ansible-lint.yml
+++ b/TEMPLATES/.ansible-lint.yml
@@ -36,6 +36,7 @@ skip_list:
   - 'command-instead-of-shell'  # Allow use of shell when you want
   - 'no-handler'  # Allow step to run like handler
   - 'unnamed-task' # Allow tasks without a name
+  - 'yaml' # Disable YAML linting since it's done by yamllint
 
 ##################
 # Tags to follow #


### PR DESCRIPTION
Ansible Lint's YAML linting is not needed since super-linter already contains yamllint. This also fixes the conflict explained in #2818 between Ansible Lint's yamllint and super-linter's yamllint.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #2818 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Disable YAML linting in ansible-lint

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
