### PR TITLE
Remove non-working cauldron report

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ It is a simple combination of various linters, written in `bash`, to help valida
     - [GitLab](#gitlab)
     - [Codespaces and Visual Studio Code](#codespaces-and-visual-studio-code)
     - [SSL Certs](#ssl-certs)
-  - [Community Activity](#community-activity)
   - [Limitations](#limitations)
   - [How to contribute](#how-to-contribute)
     - [License](#license)
@@ -554,10 +553,6 @@ Once found, it will load the certificate contents to a file, and to the trust st
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     SSL_CERT_SECRET: ${{ secrets.ROOT_CA }}
 ```
-
-## Community Activity
-
-![super-linter stats](https://cauldron.io/project/2083/stats.svg)
 
 ## Limitations
 


### PR DESCRIPTION
## Proposed Changes

1. Remove the cauldron.io report because it's not working and I we don't have administrative access to that.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
