### PR TITLE
Assign the RELEASE_VERSION variable

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -50,7 +50,8 @@ jobs:
           >> "${GITHUB_ENV}"
           if [ -z "${RELEASE_VERSION}" ]; then
             echo "No release version found in environment, using input..."
-            echo "RELEASE_VERSION=${{ github.event.inputs.release_version }}" \
+            RELEASE_VERSION="${{ github.event.inputs.release_version }}"
+            echo "RELEASE_VERSION=${RELEASE_VERSION}" \
             >> "${GITHUB_ENV}"
           fi
           {


### PR DESCRIPTION
Fixes #3384

## Proposed Changes

1. Assign the `RELEASE_VERSION` variable when the workflow is manually triggered.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
