### PR TITLE
Assign RELEASE_VERSION before using it

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -45,16 +45,22 @@ jobs:
       - name: Get current release identifier
         # shellcheck disable=SC2062
         run: |
-          echo "RELEASE_VERSION=$(echo ${{ github.event.release.name }} \
-          | grep -E -o "v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+")" \
-          >> "${GITHUB_ENV}"
+          RELESE_VERSION="$(echo ${{ github.event.release.name }} \
+            | grep -E -o "v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+")"
+
           if [ -z "${RELEASE_VERSION}" ]; then
             echo "No release version found in environment, using input..."
             RELEASE_VERSION="${{ github.event.inputs.release_version }}"
-            echo "RELEASE_VERSION=${RELEASE_VERSION}" \
-            >> "${GITHUB_ENV}"
           fi
+
+          # Check the RELEASE_VERSION again
+          if [ -z "${RELEASE_VERSION}" ]; then
+            echo "Error RELEASE_VERSION is empty. Exiting..."
+            exit 1
+          fi
+
           {
+            echo "RELEASE_VERSION=${RELESE_VERSION}"
             echo "SEMVER_VERSION=${RELEASE_VERSION#v}"
             echo "SEMVER_MAJOR_VERSION=${SEMVER_VERSION%%.*}"
             echo "SEMVER_MAJOR_VERSION_WITH_PREFIX=v${SEMVER_MAJOR_VERSION}"


### PR DESCRIPTION
Fixes #3411
Fixes #3412

## Proposed Changes

1. Initialize the `RELEASE_VERSION` variable before using it.
2. Update the `GITHUB_ENV` variable in a single place.
3. Check if the `RELEASE_VERSION` has a value before going on.

Once this is merged, we should re-run the related workflow manually.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
