### PR TITLE
Use TFLINT_LOG environment variable instead of the deprecated --loglevel option

### DIFF
--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -509,12 +509,13 @@ function RunAdditionalInstalls() {
     if [ "${ACTIONS_RUNNER_DEBUG}" = "true" ]; then
       TF_LOG_LEVEL="debug"
     fi
+    debug "Set the tflint log level to: ${TF_LOG_LEVEL}"
     #########################
     # Run the build command #
     #########################
     BUILD_CMD=$(
       cd "${WORKSPACE_PATH}" || exit 0
-      tflint --init --loglevel="${TF_LOG_LEVEL}" -c "${TERRAFORM_TFLINT_LINTER_RULES}" 2>&1
+      TFLINT_LOG="${TF_LOG_LEVEL}" tflint --init -c "${TERRAFORM_TFLINT_LINTER_RULES}" 2>&1
     )
 
     ##############


### PR DESCRIPTION
Fixes 3406

## Proposed Changes

1. tflint now uses the `TFLINT_LOG` environment variable instead of the `--loglevel` switch.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
