### PR TITLE
Throw a fatal error if tflint --init fails

### DIFF
--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -526,11 +526,10 @@ function RunAdditionalInstalls() {
     # Check the shell for errors #
     ##############################
     if [ "${ERROR_CODE}" -ne 0 ]; then
-      # Error
-      warn "ERROR! Failed to run:[tflint --init] at location:[${WORKSPACE_PATH}]"
-      warn "BUILD_CMD:[${BUILD_CMD}]"
+      fatal "ERROR! Failed to run:[tflint --init] at location:[${WORKSPACE_PATH}]. BUILD_CMD:[${BUILD_CMD}]"
     else
       info "Successfully ran:[tflint --init] in workspace:[${WORKSPACE_PATH}]"
+      debug "BUILD_CMD:[${BUILD_CMD}]"
     fi
   fi
 }


### PR DESCRIPTION
## Proposed Changes

1. Exit with a fatal error if `tflint --init` fails. This will help catching issues with `tflint`, such as #3406. 

This likely needs #3414 to be merged.

Update: [fails as expected](https://github.com/github/super-linter/actions/runs/3184092387/jobs/5192101429)

```
2022-10-04 17:28:19 [FATAL]   ERROR! Failed to run:[tflint --init] at location:[/tmp/lint/.automation/test]. BUILD_CMD:[Failed to parse CLI options; `loglevel` option was removed in v0.40.0. Please set `TFLINT_LOG` environment variables instead]
```

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
