### PR TITLE
Enable stack linter on push

### DIFF
--- a/.github/workflows/stack-linter.yml
+++ b/.github/workflows/stack-linter.yml
@@ -16,6 +16,7 @@ name: Stack Linter
 # Start the job on all push #
 #############################
 on:
+  push:
   pull_request:
 
 ###############


### PR DESCRIPTION
## Proposed Changes

1. The `Stack Linter` check is required, but it doesn't run on pushes. This PR fixes this issue by enable that check on pushes as well.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
