### PR TITLE
add jenkinsfile to groovy files

### DIFF
--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -438,8 +438,10 @@ function BuildFileList() {
     ########################
     # Get the GROOVY files #
     ########################
+    # Use BASE_FILE here because FILE_TYPE is not reliable when there is no file extension
     elif [ "$FILE_TYPE" == "groovy" ] || [ "$FILE_TYPE" == "jenkinsfile" ] ||
-      [ "$FILE_TYPE" == "gradle" ] || [ "$FILE_TYPE" == "nf" ]; then
+      [ "$FILE_TYPE" == "gradle" ] || [ "$FILE_TYPE" == "nf" ] ||
+      [[ "$BASE_FILE" =~ .*jenkinsfile.* ]]; then
       ################################
       # Append the file to the array #
       ################################


### PR DESCRIPTION
add jenkinsfile to groovy files when file has no extension: eg `Jenkinsfile`

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. When a file `Jenkinsfile` with no extension is found, add to the Groovy files lint. This was based on the docker file `elif` check on line 425.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
I don't think any additional documentation is needed for this change.

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
