### PR TITLE
Bump actionlint to 1.6.22 from 1.6.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM hashicorp/terraform:1.3.2 as terraform
 FROM koalaman/shellcheck:v0.8.0 as shellcheck
 FROM mstruebing/editorconfig-checker:2.4.0 as editorconfig-checker
 FROM mvdan/shfmt:v3.5.1 as shfmt
-FROM rhysd/actionlint:1.6.21 as actionlint
+FROM rhysd/actionlint:1.6.22 as actionlint
 FROM scalameta/scalafmt:v3.5.9 as scalafmt
 FROM yoheimuta/protolint:0.41.0 as protolint
 FROM zricethezav/gitleaks:v8.13.0 as gitleaks


### PR DESCRIPTION
This latest version contains fixes such as preventing false positives from evaluated defaults

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->
 Issue is located at rhysd/actionlint with number 235
https://github.com/rhysd/actionlint/issues/235

Fixes #

<!-- markdownlint-restore -->

Update actionlint version from 1.6.21 to 1.6.22

## Proposed Changes

1. Update actionlint version from 1.6.21 to 1.6.22

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
