### PR TITLE
Stylelint support prettier plugin

### DIFF
--- a/dependencies/package-lock.json
+++ b/dependencies/package-lock.json
@@ -48,6 +48,7 @@
         "stylelint-config-sass-guidelines": "^9.0.1",
         "stylelint-config-standard": "^29.0.0",
         "stylelint-config-standard-scss": "^6.1.0",
+        "stylelint-prettier": "^2.0.0",
         "stylelint-scss": "^4.3.0",
         "tekton-lint": "^0.6.0",
         "textlint": "^12.2.4",
@@ -9391,6 +9392,21 @@
         "stylelint": "^14.0.0"
       }
     },
+    "node_modules/stylelint-prettier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-prettier/-/stylelint-prettier-2.0.0.tgz",
+      "integrity": "sha512-jvT3G+9lopkeB0ARmDPszyfaOnvnIF+30QCjZxyt7E6fynI1T9mOKgYDNb9bXX17M7PXMZaX3j/26wqakjp1tw==",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "prettier": ">=2.0.0",
+        "stylelint": ">=14.0.0"
+      }
+    },
     "node_modules/stylelint-scss": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.3.0.tgz",
@@ -17704,6 +17720,14 @@
       "requires": {
         "postcss": "^8.3.11",
         "postcss-sorting": "^7.0.1"
+      }
+    },
+    "stylelint-prettier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-prettier/-/stylelint-prettier-2.0.0.tgz",
+      "integrity": "sha512-jvT3G+9lopkeB0ARmDPszyfaOnvnIF+30QCjZxyt7E6fynI1T9mOKgYDNb9bXX17M7PXMZaX3j/26wqakjp1tw==",
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "stylelint-scss": {

--- a/dependencies/package.json
+++ b/dependencies/package.json
@@ -42,6 +42,7 @@
     "stylelint-config-standard": "^29.0.0",
     "stylelint-config-standard-scss": "^6.1.0",
     "stylelint-config-prettier": "^9.0.4",
+    "stylelint-prettier": "^2.0.0",
     "postcss-less": "^6.0.0",
     "stylelint-scss": "^4.3.0",
     "tekton-lint": "^0.6.0",


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes an issue using stylelint with prettier plugin.
Can be seen as follow up to #2808. The original PR does not include the prettier plugin, which is needed to let stylelint function properly with prettier. See [stylelint prettier installation guide](https://github.com/prettier/stylelint-prettier#installation).

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes
Fixed an error while using stylelint with prettier plugin.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
