### PR TITLE
Push scripts into standalone files and authenticate requests

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -57,7 +57,7 @@ jobs:
           load: true
           push: false
           secrets: |
-            GITHUB_TOKEN=GITHUB_TOKEN${{ secrets.GITHUB_TOKEN }}
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/github/super-linter:${{ matrix.images.container-image-id-prefix }}${{ github.sha }}
             ghcr.io/github/super-linter:${{ matrix.images.container-image-id-prefix }}test

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -54,9 +54,10 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             BUILD_REVISION=${{ github.sha }}
             BUILD_VERSION=${{ github.sha }}
-            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           load: true
           push: false
+          secrets: |
+            GITHUB_TOKEN=GITHUB_TOKEN${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/github/super-linter:${{ matrix.images.container-image-id-prefix }}${{ github.sha }}
             ghcr.io/github/super-linter:${{ matrix.images.container-image-id-prefix }}test
@@ -179,9 +180,10 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             BUILD_REVISION=${{ github.sha }}
             BUILD_VERSION=${{ github.sha }}
-            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           load: false
           push: true
+          secrets: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
             github/super-linter:${{ matrix.images.container-image-id-prefix }}latest
             ghcr.io/github/super-linter:${{ matrix.images.container-image-id-prefix }}latest

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -54,6 +54,7 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             BUILD_REVISION=${{ github.sha }}
             BUILD_VERSION=${{ github.sha }}
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           load: true
           push: false
           tags: |
@@ -178,6 +179,7 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             BUILD_REVISION=${{ github.sha }}
             BUILD_VERSION=${{ github.sha }}
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           load: false
           push: true
           tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -262,39 +262,6 @@ ENV IMAGE="slim"
 # Store the key here because the above host is sometimes down, and breaks our builds
 COPY dependencies/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
 
-<<<<<<< HEAD
-######################################
-# Install Phive dependencies and git #
-######################################
-RUN wget --tries=5 -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
-    && apk update && apk upgrade && apk add --no-cache --force-overwrite \
-    bash \
-    ca-certificates \
-    curl \
-    git git-lfs \
-    glibc-${GLIBC_VERSION}.apk \
-    tar zstd \
-    gnupg \
-    php81 php81-curl php81-ctype php81-dom php81-iconv php81-mbstring \
-    php81-openssl php81-phar php81-simplexml php81-tokenizer php81-xmlwriter \
-    && rm glibc-${GLIBC_VERSION}.apk \
-    && wget -q --tries=5 -O /tmp/libz.tar.zst https://www.archlinux.org/packages/core/x86_64/zlib/download \
-    && mkdir /tmp/libz \
-    && tar -xf /tmp/libz.tar.zst -C /tmp/libz --zstd \
-    && mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib \
-    && rm -rf /tmp/libz /tmp/libz.tar.zst \
-    && wget -q --tries=5 -O phive.phar https://phar.io/releases/phive.phar \
-    && wget -q --tries=5 -O phive.phar.asc https://phar.io/releases/phive.phar.asc \
-    && PHAR_KEY_ID="0x9D8A98B29B2D5D79" \
-    && gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$PHAR_KEY_ID" \
-    && gpg --verify phive.phar.asc phive.phar \
-    && chmod +x phive.phar \
-    && mv phive.phar /usr/local/bin/phive \
-    && rm phive.phar.asc \
-    && phive --no-progress install --trust-gpg-keys \
-    31C7E470E2138192,CF1A108D0E7AE720,8A03EA3B385DBAA1,12CE0F1D262429A5 \
-    --target /usr/bin phpstan@^1.3.3 psalm@^4.18.1 phpcs@^3.6.2
-=======
 ###############
 # Install Git #
 ###############
@@ -305,7 +272,6 @@ RUN apk add --no-cache bash git git-lfs
 ##############################
 COPY scripts/install-phive.sh /
 RUN /install-phive.sh && rm -rf /install-phive.sh
->>>>>>> 65949c12 (Push scripts into standalone files)
 
 ####################################################
 # Install Composer after all Libs have been copied #

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ ARG CHECKSTYLE_VERSION='10.3.4'
 # Dart Linter
 ## stable dart sdk: https://dart.dev/get-dart#release-channels
 ARG DART_VERSION='2.8.4'
-ARG GITHUB_TOKEN
 ARG GOOGLE_JAVA_FORMAT_VERSION='1.15.0'
 ## install alpine-pkg-glibc (glibc compatibility layer package for Alpine Linux)
 ARG GLIBC_VERSION='2.34-r0'
@@ -228,7 +227,6 @@ FROM alpine:3.17.0 as final_slim
 ARG BUILD_DATE
 ARG BUILD_REVISION
 ARG BUILD_VERSION
-ARG GITHUB_TOKEN
 ## install alpine-pkg-glibc (glibc compatibility layer package for Alpine Linux)
 ARG GLIBC_VERSION='2.34-r0'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -393,7 +393,7 @@ FROM final_slim as final_standard
 ARG GITHUB_TOKEN
 ARG PWSH_VERSION='latest'
 ARG PWSH_DIRECTORY='/usr/lib/microsoft/powershell'
-ARG PSSA_VERSION='latest'
+ARG PSSA_VERSION='1.21.0'
 
 ################
 # Set ENV vars #

--- a/Dockerfile
+++ b/Dockerfile
@@ -398,6 +398,7 @@ ARG PSSA_VERSION='1.21.0'
 ################
 # Set ENV vars #
 ################
+ENV ARM_TTK_PSD1="/usr/lib/microsoft/arm-ttk/arm-ttk.psd1"
 ENV IMAGE="standard"
 ENV PATH="${PATH}:/var/cache/dotnet/tools:/usr/share/dotnet"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,9 @@ ARG GOOGLE_JAVA_FORMAT_VERSION='1.15.0'
 ARG GLIBC_VERSION='2.34-r0'
 ARG KTLINT_VERSION='0.47.1'
 # PowerShell & PSScriptAnalyzer linter
-ARG PSSA_VERSION='latest'
+ARG PSSA_VERSION='1.21.0'
 ARG PWSH_DIRECTORY='/usr/lib/microsoft/powershell'
-ARG PWSH_VERSION='latest'
+ARG PWSH_VERSION='v7.3.1'
 # Kubeval Version
 ARG KUBEVAL_VERSION='v0.16.1'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -199,14 +199,14 @@ COPY dependencies/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
 # Install Kubeval #
 ###################
 COPY scripts/install-kubeval.sh /
-RUN /install-kubeval.sh && rm -rf /install-kubeval.sh
+RUN --mount=type=secret,id=GITHUB_TOKEN /install-kubeval.sh && rm -rf /install-kubeval.sh
 
 #################################################
 # Install Raku and additional Edge dependencies #
 #################################################
 # Basic setup, programs and init
 COPY scripts/install-raku.sh /
-RUN /install-raku.sh && rm -rf /install-raku.sh
+RUN --mount=type=secret,id=GITHUB_TOKEN /install-raku.sh && rm -rf /install-raku.sh
 
 ################################################################################
 # Grab small clean image to build python packages ##############################
@@ -271,7 +271,7 @@ RUN apk add --no-cache bash git git-lfs
 # Install Phive dependencies #
 ##############################
 COPY scripts/install-phive.sh /
-RUN /install-phive.sh && rm -rf /install-phive.sh
+RUN --mount=type=secret,id=GITHUB_TOKEN /install-phive.sh && rm -rf /install-phive.sh
 
 ####################################################
 # Install Composer after all Libs have been copied #
@@ -390,13 +390,13 @@ RUN /install-rustfmt.sh && rm -rf /install-rustfmt.sh
 # Install Powershell + PSScriptAnalyzer #
 #########################################
 COPY scripts/install-pwsh.sh /
-RUN /install-pwsh.sh && rm -rf /install-pwsh.sh
+RUN --mount=type=secret,id=GITHUB_TOKEN /install-pwsh.sh && rm -rf /install-pwsh.sh
 
 #############################################################
 # Install Azure Resource Manager Template Toolkit (arm-ttk) #
 #############################################################
 COPY scripts/install-arm-ttk.sh /
-RUN /install-arm-ttk.sh && rm -rf /install-arm-ttk.sh
+RUN --mount=type=secret,id=GITHUB_TOKEN /install-arm-ttk.sh && rm -rf /install-arm-ttk.sh
 
 ########################################################################################
 # Run to build version file and validate image again because we installed more linters #

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,6 @@ docker:
 		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
 		--build-arg BUILD_REVISION=$(shell git rev-parse --short HEAD) \
 		--build-arg BUILD_VERSION=$(shell git rev-parse --short HEAD) \
-		--build-arg GITHUB_TOKEN="${GITHUB_PAT}" \
 		-t ghcr.io/github/super-linter .
 
 .phony: docker-buildx
@@ -121,5 +120,5 @@ docker-buildx:
 		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
 		--build-arg BUILD_REVISION=$(shell git rev-parse --short HEAD) \
 		--build-arg BUILD_VERSION=$(shell git rev-parse --short HEAD) \
-		--build-arg GITHUB_TOKEN="${GITHUB_PAT}" \
+		--secret id=GITHUB_TOKEN,env=GITHUB_TOKEN \
 		-t ghcr.io/github/super-linter .

--- a/Makefile
+++ b/Makefile
@@ -103,3 +103,23 @@ inspec: inspec-check ## Run InSpec tests
 		-t "docker://$${SUPER_LINTER_TEST_CONTAINER_ID}" \
 	&& docker ps \
 	&& docker kill "$(SUPER_LINTER_TEST_CONTAINER_NAME)"
+
+.phony: docker
+docker:
+	@if [ -z "${GITHUB_TOKEN}" ]; then echo "GITHUB_TOKEN environment variable not set. Please set your GitHub Personal Access Token."; exit 1; fi
+	docker build \
+		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
+		--build-arg BUILD_REVISION=$(shell git rev-parse --short HEAD) \
+		--build-arg BUILD_VERSION=$(shell git rev-parse --short HEAD) \
+		--build-arg GITHUB_TOKEN="${GITHUB_PAT}" \
+		-t ghcr.io/github/super-linter .
+
+.phony: docker-buildx
+docker-buildx:
+	@if [ -z "${GITHUB_TOKEN}" ]; then echo "GITHUB_TOKEN environment variable not set. Please set your GitHub Personal Access Token."; exit 1; fi
+	docker buildx build --load \
+		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
+		--build-arg BUILD_REVISION=$(shell git rev-parse --short HEAD) \
+		--build-arg BUILD_VERSION=$(shell git rev-parse --short HEAD) \
+		--build-arg GITHUB_TOKEN="${GITHUB_PAT}" \
+		-t ghcr.io/github/super-linter .

--- a/Makefile
+++ b/Makefile
@@ -107,16 +107,7 @@ inspec: inspec-check ## Run InSpec tests
 .phony: docker
 docker:
 	@if [ -z "${GITHUB_TOKEN}" ]; then echo "GITHUB_TOKEN environment variable not set. Please set your GitHub Personal Access Token."; exit 1; fi
-	docker build \
-		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
-		--build-arg BUILD_REVISION=$(shell git rev-parse --short HEAD) \
-		--build-arg BUILD_VERSION=$(shell git rev-parse --short HEAD) \
-		-t ghcr.io/github/super-linter .
-
-.phony: docker-buildx
-docker-buildx:
-	@if [ -z "${GITHUB_TOKEN}" ]; then echo "GITHUB_TOKEN environment variable not set. Please set your GitHub Personal Access Token."; exit 1; fi
-	docker buildx build --load \
+	DOCKER_BUILDKIT=1 docker buildx build --load \
 		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
 		--build-arg BUILD_REVISION=$(shell git rev-parse --short HEAD) \
 		--build-arg BUILD_VERSION=$(shell git rev-parse --short HEAD) \

--- a/scripts/install-arm-ttk.sh
+++ b/scripts/install-arm-ttk.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Depends on PowerShell
+# Reference https://github.com/Azure/arm-ttk
+# Reference https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/test-toolkit
+
+url=$(curl -s \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  https://api.github.com/repos/Azure/arm-ttk/releases/latest | jq -r '.tarball_url')
+curl --retry 5 --retry-delay 5 -sL \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "${url}" | tar -xz -C /usr/lib/microsoft
+ln -sTf /usr/lib/microsoft/arm-ttk-master/arm-ttk/arm-ttk.psd1 /usr/bin/arm-ttk

--- a/scripts/install-arm-ttk.sh
+++ b/scripts/install-arm-ttk.sh
@@ -15,5 +15,7 @@ curl --retry 5 --retry-delay 5 -sL \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: Bearer ${GITHUB_TOKEN}" \
   "${url}" | tar -xz -C /usr/lib/microsoft
-chmod a+x /usr/lib/microsoft/*/arm-ttk/arm-ttk.psd1
-ln -sTf /usr/lib/microsoft/*/arm-ttk/arm-ttk.psd1 /usr/bin/arm-ttk
+mv /usr/lib/microsoft/Azure-arm-ttk-*/arm-ttk /usr/lib/microsoft/arm-ttk
+rm -rf /usr/lib/microsoft/Azure-arm-ttk-*
+chmod a+x /usr/lib/microsoft/arm-ttk/arm-ttk.psd1
+ln -sTf /usr/lib/microsoft/arm-ttk/arm-ttk.psd1 /usr/bin/arm-ttk

--- a/scripts/install-arm-ttk.sh
+++ b/scripts/install-arm-ttk.sh
@@ -8,12 +8,12 @@ set -euo pipefail
 
 url=$(curl -s \
   -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   https://api.github.com/repos/Azure/arm-ttk/releases/latest | jq -r '.tarball_url')
 mkdir -p /usr/lib/microsoft
 curl --retry 5 --retry-delay 5 -sL \
   -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "${url}" | tar -xz -C /usr/lib/microsoft
 mv /usr/lib/microsoft/Azure-arm-ttk-*/arm-ttk /usr/lib/microsoft/arm-ttk
 rm -rf /usr/lib/microsoft/Azure-arm-ttk-*

--- a/scripts/install-arm-ttk.sh
+++ b/scripts/install-arm-ttk.sh
@@ -10,8 +10,10 @@ url=$(curl -s \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: Bearer ${GITHUB_TOKEN}" \
   https://api.github.com/repos/Azure/arm-ttk/releases/latest | jq -r '.tarball_url')
+mkdir -p /usr/lib/microsoft
 curl --retry 5 --retry-delay 5 -sL \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: Bearer ${GITHUB_TOKEN}" \
   "${url}" | tar -xz -C /usr/lib/microsoft
-ln -sTf /usr/lib/microsoft/arm-ttk-master/arm-ttk/arm-ttk.psd1 /usr/bin/arm-ttk
+chmod a+x /usr/lib/microsoft/*/arm-ttk/arm-ttk.psd1
+ln -sTf /usr/lib/microsoft/*/arm-ttk/arm-ttk.psd1 /usr/bin/arm-ttk

--- a/scripts/install-dotnet.sh
+++ b/scripts/install-dotnet.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+curl --retry 5 --retry-delay 5 -sLO https://dot.net/v1/dotnet-install.sh
+chmod +x dotnet-install.sh
+./dotnet-install.sh --install-dir /usr/share/dotnet -channel STS -version latest
+/usr/share/dotnet/dotnet tool install --tool-path /usr/bin dotnet-format --version 5.0.211103

--- a/scripts/install-kubeval.sh
+++ b/scripts/install-kubeval.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+url=$(curl -s \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "https://api.github.com/repos/instrumenta/kubeval/releases/tags/${KUBEVAL_VERSION}" |
+  jq -r '.assets | .[] | select(.name | contains("linux-amd")) | .url')
+curl --retry 5 --retry-delay 5 -sL \
+  -H "Accept: application/octet-stream" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "${url}" | tar -xz
+mv kubeval /usr/local/bin
+
+##################
+# Install ktlint #
+##################
+url=$(curl -s \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "https://api.github.com/repos/pinterest/ktlint/releases/tags/${KTLINT_VERSION}" |
+  jq -r '.assets | .[] | select(.name=="ktlint") | .url')
+curl --retry 5 --retry-delay 5 -sL -o "/usr/bin/ktlint" \
+  -H "Accept: application/octet-stream" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "${url}"
+chmod a+x /usr/bin/ktlint
+terrascan init
+cd ~ && touch .chktexrc
+
+####################
+# Install dart-sdk #
+####################
+url=$(curl -s \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "https://api.github.com/repos/sgerrand/alpine-pkg-glibc/releases/tags/${GLIBC_VERSION}" |
+  jq --arg name "glibc-${GLIBC_VERSION}.apk" -r '.assets | .[] | select(.name | contains($name)) | .url')
+curl --retry 5 --retry-delay 5 -sL -o "glibc-${GLIBC_VERSION}.apk" \
+  -H "Accept: application/octet-stream" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "${url}"
+apk add --no-cache "glibc-${GLIBC_VERSION}.apk"
+rm "glibc-${GLIBC_VERSION}.apk"
+
+curl --retry 5 --retry-delay 5 -sO "https://storage.googleapis.com/dart-archive/channels/stable/release/${DART_VERSION}/sdk/dartsdk-linux-x64-release.zip"
+unzip -q dartsdk-linux-x64-release.zip
+chmod +x dart-sdk/bin/dart* && mv dart-sdk/bin/* /usr/bin/ && mv dart-sdk/lib/* /usr/lib/ && mv dart-sdk/include/* /usr/include/
+rm -r dart-sdk/ dartsdk-linux-x64-release.zip
+
+################################
+# Create and install Bash-Exec #
+################################
+# shellcheck disable=SC2016
+printf '#!/bin/bash\nif [[ -x "$1" ]]; then exit 0; else echo "Error: File:[$1] is not executable"; exit 1; fi' >/usr/bin/bash-exec
+chmod +x /usr/bin/bash-exec

--- a/scripts/install-kubeval.sh
+++ b/scripts/install-kubeval.sh
@@ -41,7 +41,7 @@ curl --retry 5 --retry-delay 5 -sL -o "glibc-${GLIBC_VERSION}.apk" \
   -H "Accept: application/octet-stream" \
   -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "${url}"
-apk add --no-cache "glibc-${GLIBC_VERSION}.apk"
+apk add --no-cache --force-overwrite "glibc-${GLIBC_VERSION}.apk"
 rm "glibc-${GLIBC_VERSION}.apk"
 
 curl --retry 5 --retry-delay 5 -sO "https://storage.googleapis.com/dart-archive/channels/stable/release/${DART_VERSION}/sdk/dartsdk-linux-x64-release.zip"

--- a/scripts/install-kubeval.sh
+++ b/scripts/install-kubeval.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 
 url=$(curl -s \
   -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "https://api.github.com/repos/instrumenta/kubeval/releases/tags/${KUBEVAL_VERSION}" |
   jq -r '.assets | .[] | select(.name | contains("linux-amd")) | .url')
 curl --retry 5 --retry-delay 5 -sL \
   -H "Accept: application/octet-stream" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "${url}" | tar -xz
 mv kubeval /usr/local/bin
 
@@ -18,12 +18,12 @@ mv kubeval /usr/local/bin
 ##################
 url=$(curl -s \
   -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "https://api.github.com/repos/pinterest/ktlint/releases/tags/${KTLINT_VERSION}" |
   jq -r '.assets | .[] | select(.name=="ktlint") | .url')
 curl --retry 5 --retry-delay 5 -sL -o "/usr/bin/ktlint" \
   -H "Accept: application/octet-stream" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "${url}"
 chmod a+x /usr/bin/ktlint
 terrascan init
@@ -34,12 +34,12 @@ cd ~ && touch .chktexrc
 ####################
 url=$(curl -s \
   -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "https://api.github.com/repos/sgerrand/alpine-pkg-glibc/releases/tags/${GLIBC_VERSION}" |
   jq --arg name "glibc-${GLIBC_VERSION}.apk" -r '.assets | .[] | select(.name | contains($name)) | .url')
 curl --retry 5 --retry-delay 5 -sL -o "glibc-${GLIBC_VERSION}.apk" \
   -H "Accept: application/octet-stream" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "${url}"
 apk add --no-cache "glibc-${GLIBC_VERSION}.apk"
 rm "glibc-${GLIBC_VERSION}.apk"

--- a/scripts/install-lintr.sh
+++ b/scripts/install-lintr.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mkdir -p /home/r-library
+cp -r /usr/lib/R/library/ /home/r-library/
+Rscript -e "install.packages(c('lintr','purrr'), repos = 'https://cloud.r-project.org/')"
+R -e "install.packages(list.dirs('/home/r-library',recursive = FALSE), repos = NULL, type = 'source')"

--- a/scripts/install-phive.sh
+++ b/scripts/install-phive.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+apk add curl jq
+url=$(curl -s \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "https://api.github.com/repos/sgerrand/alpine-pkg-glibc/releases/tags/${GLIBC_VERSION}" |
+  jq --arg name "glibc-${GLIBC_VERSION}.apk" -r '.assets | .[] | select(.name | contains($name)) | .url')
+curl --retry 5 --retry-delay 5 -sL -o "glibc-${GLIBC_VERSION}.apk" \
+  -H "Accept: application/octet-stream" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "${url}"
+apk add --no-cache \
+  bash \
+  ca-certificates \
+  "glibc-${GLIBC_VERSION}.apk" \
+  gnupg \
+  php7 php7-curl php7-ctype php7-dom php7-iconv php7-json php7-mbstring \
+  php7-openssl php7-phar php7-simplexml php7-tokenizer php-xmlwriter \
+  tar zstd
+rm "glibc-${GLIBC_VERSION}.apk"
+mkdir /tmp/libz
+curl --retry 5 --retry-delay 5 -sL https://www.archlinux.org/packages/core/x86_64/zlib/download | tar -x --zstd -C /tmp/libz
+mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib
+rm -rf /tmp/libz
+curl --retry 5 --retry-delay 5 -sLO https://phar.io/releases/phive.phar
+curl --retry 5 --retry-delay 5 -sLO https://phar.io/releases/phive.phar.asc
+gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "0x9D8A98B29B2D5D79"
+gpg --verify phive.phar.asc phive.phar
+chmod +x phive.phar
+mv phive.phar /usr/local/bin/phive
+rm phive.phar.asc
+phive --no-progress install --trust-gpg-keys 31C7E470E2138192,CF1A108D0E7AE720,8A03EA3B385DBAA1,12CE0F1D262429A5 --target /usr/bin phpstan@^1.3.3 psalm@^4.18.1 phpcs@^3.6.2

--- a/scripts/install-phive.sh
+++ b/scripts/install-phive.sh
@@ -13,13 +13,13 @@ curl --retry 5 --retry-delay 5 -sL -o "glibc-${GLIBC_VERSION}.apk" \
   -H "Accept: application/octet-stream" \
   -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "${url}"
-apk add --no-cache \
+apk add --no-cache --force-overwrite \
   bash \
   ca-certificates \
   "glibc-${GLIBC_VERSION}.apk" \
   gnupg \
-  php7 php7-curl php7-ctype php7-dom php7-iconv php7-json php7-mbstring \
-  php7-openssl php7-phar php7-simplexml php7-tokenizer php-xmlwriter \
+  php81 php81-curl php81-ctype php81-dom php81-iconv php81-mbstring \
+  php81-openssl php81-phar php81-simplexml php81-tokenizer php81-xmlwriter \
   tar zstd
 rm "glibc-${GLIBC_VERSION}.apk"
 mkdir /tmp/libz

--- a/scripts/install-phive.sh
+++ b/scripts/install-phive.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+set -x
 
 apk add curl jq
 url=$(curl -s \

--- a/scripts/install-phive.sh
+++ b/scripts/install-phive.sh
@@ -6,12 +6,12 @@ set -x
 apk add curl jq
 url=$(curl -s \
   -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "https://api.github.com/repos/sgerrand/alpine-pkg-glibc/releases/tags/${GLIBC_VERSION}" |
   jq --arg name "glibc-${GLIBC_VERSION}.apk" -r '.assets | .[] | select(.name | contains($name)) | .url')
 curl --retry 5 --retry-delay 5 -sL -o "glibc-${GLIBC_VERSION}.apk" \
   -H "Accept: application/octet-stream" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "${url}"
 apk add --no-cache \
   bash \

--- a/scripts/install-pwsh.sh
+++ b/scripts/install-pwsh.sh
@@ -9,12 +9,12 @@ set -euo pipefail
 mkdir -p "${PWSH_DIRECTORY}"
 url=$(curl -s \
   -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "https://api.github.com/repos/powershell/powershell/releases/${PWSH_VERSION}" |
   jq -r '.assets | .[] | select(.name | contains("linux-alpine-x64")) | .url')
 curl --retry 5 --retry-delay 5 -sL \
   -H "Accept: application/octet-stream" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "${url}" | tar -xz -C "${PWSH_DIRECTORY}"
 chmod +x "${PWSH_DIRECTORY}/pwsh"
 ln -sf "${PWSH_DIRECTORY}/pwsh" /usr/bin/pwsh

--- a/scripts/install-pwsh.sh
+++ b/scripts/install-pwsh.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Reference: https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-linux?view=powershell-7
+# Slightly modified to always retrieve latest stable Powershell version
+# If changing PWSH_VERSION='latest' to a specific version, use format PWSH_VERSION='tags/v7.0.2'
+
+mkdir -p "${PWSH_DIRECTORY}"
+url=$(curl -s \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "https://api.github.com/repos/powershell/powershell/releases/${PWSH_VERSION}" |
+  jq -r '.assets | .[] | select(.name | contains("linux-alpine-x64")) | .url')
+curl --retry 5 --retry-delay 5 -sL \
+  -H "Accept: application/octet-stream" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "${url}" | tar -xz -C "${PWSH_DIRECTORY}"
+chmod +x "${PWSH_DIRECTORY}/pwsh"
+ln -sf "${PWSH_DIRECTORY}/pwsh" /usr/bin/pwsh
+pwsh -c "Install-Module -Name PSScriptAnalyzer -RequiredVersion ${PSSA_VERSION} -Scope AllUsers -Force"

--- a/scripts/install-raku.sh
+++ b/scripts/install-raku.sh
@@ -9,12 +9,12 @@ apk add --no-cache rakudo zef
 ######################
 url=$(curl -s \
   -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "https://api.github.com/repos/checkstyle/checkstyle/releases/tags/checkstyle-${CHECKSTYLE_VERSION}" |
   jq --arg name "checkstyle-${CHECKSTYLE_VERSION}-all.jar" -r '.assets | .[] | select(.name==$name) | .url')
 curl --retry 5 --retry-delay 5 -sL -o /usr/bin/checkstyle \
   -H "Accept: application/octet-stream" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "${url}"
 chmod a+x /usr/bin/checkstyle
 
@@ -23,12 +23,12 @@ chmod a+x /usr/bin/checkstyle
 ##############################
 url=$(curl -s \
   -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "https://api.github.com/repos/google/google-java-format/releases/tags/v${GOOGLE_JAVA_FORMAT_VERSION}" |
   jq --arg name "google-java-format-${GOOGLE_JAVA_FORMAT_VERSION}-all-deps.jar" -r '.assets | .[] | select(.name==$name) | .url')
 curl --retry 5 --retry-delay 5 -sL -o /usr/bin/google-java-format \
   -H "Accept: application/octet-stream" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "${url}"
 chmod a+x /usr/bin/google-java-format
 
@@ -43,11 +43,11 @@ cd .. && rm -r lua-5.3.5/
 
 url=$(curl -s \
   -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   https://api.github.com/repos/cvega/luarocks/releases/latest | jq -r '.tarball_url')
 curl --retry 5 --retry-delay 5 -sL \
   -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
   "${url}" | tar -xz
 cd cvega-luarocks-6b1aee6
 ./configure --with-lua-include=/usr/local/include

--- a/scripts/install-raku.sh
+++ b/scripts/install-raku.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+apk add --no-cache rakudo zef
+
+######################
+# Install CheckStyle #
+######################
+url=$(curl -s \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "https://api.github.com/repos/checkstyle/checkstyle/releases/tags/checkstyle-${CHECKSTYLE_VERSION}" |
+  jq --arg name "checkstyle-${CHECKSTYLE_VERSION}-all.jar" -r '.assets | .[] | select(.name==$name) | .url')
+curl --retry 5 --retry-delay 5 -sL -o /usr/bin/checkstyle \
+  -H "Accept: application/octet-stream" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "${url}"
+chmod a+x /usr/bin/checkstyle
+
+##############################
+# Install google-java-format #
+##############################
+url=$(curl -s \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "https://api.github.com/repos/google/google-java-format/releases/tags/v${GOOGLE_JAVA_FORMAT_VERSION}" |
+  jq --arg name "google-java-format-${GOOGLE_JAVA_FORMAT_VERSION}-all-deps.jar" -r '.assets | .[] | select(.name==$name) | .url')
+curl --retry 5 --retry-delay 5 -sL -o /usr/bin/google-java-format \
+  -H "Accept: application/octet-stream" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "${url}"
+chmod a+x /usr/bin/google-java-format
+
+#################################
+# Install luacheck and luarocks #
+#################################
+curl --retry 5 --retry-delay 5 -s https://www.lua.org/ftp/lua-5.3.5.tar.gz | tar -xz
+cd lua-5.3.5
+make linux
+make install
+cd .. && rm -r lua-5.3.5/
+
+url=$(curl -s \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  https://api.github.com/repos/cvega/luarocks/releases/latest | jq -r '.tarball_url')
+curl --retry 5 --retry-delay 5 -sL \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "${url}" | tar -xz
+cd cvega-luarocks-6b1aee6
+./configure --with-lua-include=/usr/local/include
+make
+make -b install
+cd ..
+rm -r cvega-luarocks-6b1aee6
+
+luarocks install luacheck
+luarocks install argparse
+luarocks install luafilesystem
+mv /etc/R/* /usr/lib/R/etc/
+find /usr/ -type f -name '*.md' -exec rm {} +

--- a/scripts/install-rustfmt.sh
+++ b/scripts/install-rustfmt.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# shellcheck disable=SC2129
+
+set -euo pipefail
+
+ln -s /usr/bin/rustup-init /usr/bin/rustup
+rustup toolchain install stable-x86_64-unknown-linux-musl
+rustup component add rustfmt --toolchain=stable-x86_64-unknown-linux-musl
+rustup component add clippy --toolchain=stable-x86_64-unknown-linux-musl
+mv /root/.rustup /usr/lib/.rustup
+ln -fsv /usr/lib/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/rustfmt /usr/bin/rustfmt
+ln -fsv /usr/lib/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/rustc /usr/bin/rustc
+ln -fsv /usr/lib/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/cargo /usr/bin/cargo
+ln -fsv /usr/lib/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/cargo-clippy /usr/bin/cargo-clippy
+
+echo '#!/usr/bin/env bash' >/usr/bin/clippy
+echo 'pushd $(dirname $1)' >>/usr/bin/clippy
+echo 'cargo-clippy' >>/usr/bin/clippy
+echo 'rc=$?' >>/usr/bin/clippy
+echo 'popd' >>/usr/bin/clippy
+echo 'exit $rc' >>/usr/bin/clippy
+chmod +x /usr/bin/clippy


### PR DESCRIPTION
Pushes inline scripts in the Dockerfile into standalone scripts and authenticates requests to GitHub using a the GITHUB_TOKEN to reduce build flakiness due to GitHub's abuse and rate limiting due to unauthenticated requests.

The GITHUB_TOKEN is injected via a docker secret. The `docker` directive has been added to the Makefile which validates the user has properly set the GITHUB_TOKEN environment variable on their local machine before building.

Signed-off-by: Brett Logan <lindluni@github.com>
