### PR TITLE
Add terraform_fmt to inspec tests

### DIFF
--- a/test/inspec/super-linter/controls/super_linter.rb
+++ b/test/inspec/super-linter/controls/super_linter.rb
@@ -149,6 +149,7 @@ control "super-linter-installed-commands" do
     { linter_name: "standard"},
     { linter_name: "stylelint"},
     { linter_name: "tekton-lint"},
+    { linter_name: "terraform_fmt", version_command: "terraform fmt --version"}
     { linter_name: "terragrunt"},
     { linter_name: "terrascan", version_option: "version"},
     { linter_name: "tflint"},

--- a/test/inspec/super-linter/controls/super_linter.rb
+++ b/test/inspec/super-linter/controls/super_linter.rb
@@ -149,7 +149,7 @@ control "super-linter-installed-commands" do
     { linter_name: "standard"},
     { linter_name: "stylelint"},
     { linter_name: "tekton-lint"},
-    { linter_name: "terraform_fmt", version_command: "terraform fmt --version"},
+    { linter_name: "terraform"},
     { linter_name: "terragrunt"},
     { linter_name: "terrascan", version_option: "version"},
     { linter_name: "tflint"},

--- a/test/inspec/super-linter/controls/super_linter.rb
+++ b/test/inspec/super-linter/controls/super_linter.rb
@@ -149,7 +149,7 @@ control "super-linter-installed-commands" do
     { linter_name: "standard"},
     { linter_name: "stylelint"},
     { linter_name: "tekton-lint"},
-    { linter_name: "terraform_fmt", version_command: "terraform fmt --version"}
+    { linter_name: "terraform_fmt", version_command: "terraform fmt --version"},
     { linter_name: "terragrunt"},
     { linter_name: "terrascan", version_option: "version"},
     { linter_name: "tflint"},


### PR DESCRIPTION
While calling `terraform --version` or `terraform fmt --version` produce the same output, I'd like to be explicit and call `terraform fmt --version` to monitor for changed behavior using this test.

Signed-off-by: Brett Logan <lindluni@github.com>
