### PR TITLE
Docker: Use image as input instead of hard-coded value

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,8 @@ echo "@generated" # @not-generated
 
 The **Docker** container that is built from this repository is located at [github/super-linter](https://hub.docker.com/r/github/super-linter)
 
+If you would like to use your own container registry instead, please set the `image` input attribute when calling the action.
+
 ## Run Super-Linter outside GitHub Actions
 
 ### Local (troubleshooting/debugging/enhancements)

--- a/action.yml
+++ b/action.yml
@@ -2,9 +2,13 @@
 name: 'Super-Linter'
 author: 'GitHub'
 description: 'It is a simple combination of various linters, written in bash, to help validate your source code.'
+inputs:
+  image:
+    description: 'Docker image to run the super-linter. If you are internally hosting this, use the link to your internal container registry.'
+    default: 'docker://ghcr.io/github/super-linter:v4.10.1'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/github/super-linter:v4.10.1'
+  image: ${{ inputs.image }}
 branding:
   icon: 'check-square'
   color: 'white'


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->


<!-- markdownlint-restore -->

The current form of the `super-linter` contains a hard-coded docker image. We are using an internally hosted GitHub Enterprise and Actions.

These actions cannot connect to the internet to pull the image.

This PR allows users to specify the Docker image as an input and point it to their own container registry.

## Proposed Changes

1. Remove hard-coded Docker image.
2. Add image as an input parameter.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
