### PR TITLE
Document GITHUB_TOKEN permissions for MULTI_STATUS to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ jobs:
     # Set the agent to run on
     runs-on: ubuntu-latest
 
+    ############################################
+    # Grant status permission for MULTI_STATUS #
+    ############################################
+    permissions:
+      contents: read
+      packages: read
+      statuses: write
+
     ##################
     # Load all steps #
     ##################

--- a/TEMPLATES/linter.yml
+++ b/TEMPLATES/linter.yml
@@ -31,6 +31,14 @@ jobs:
     # Set the agent to run on
     runs-on: ubuntu-latest
 
+    ############################################
+    # Grant status permission for MULTI_STATUS #
+    ############################################
+    permissions:
+      contents: read
+      packages: read
+      statuses: write
+
     ##################
     # Load all steps #
     ##################


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Addresses #3137, #3387 (and similar) by making the `permissions` requirements very clear for `MULTI_STATUS` (which is `true` by default).

[Github documentation reference](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions)

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Add `permissions` property with `statuses: write` to base `README.MD`/`linter.yml` template

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
