### PR TITLE
Update all `super-linter` `v4` version references to `v5`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,9 +90,9 @@ jobs:
         with:
           src: ghcr.io/github/super-linter:${{ matrix.images.prefix }}latest
           dst: |
-            github/super-linter:${{ matrix.images.prefix }}v4
+            github/super-linter:${{ matrix.images.prefix }}v5
             github/super-linter:${{ matrix.images.prefix }}${{ env.RELEASE_VERSION }}
-            ghcr.io/github/super-linter:${{ matrix.images.prefix }}v4
+            ghcr.io/github/super-linter:${{ matrix.images.prefix }}v5
             ghcr.io/github/super-linter:${{ matrix.images.prefix }}${{ env.RELEASE_VERSION }}
 
       - name: Checkout Code

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: github/super-linter@v5
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
@@ -216,12 +216,12 @@ After further investigation, we were able to see that a few linters were very di
 This allows users to choose which **Super-Linter** they want to run and potentially speed up their build time.
 The available images:
 
-- `github/super-linter:v4`
-- `github/super-linter:slim-v4`
+- `github/super-linter:v5`
+- `github/super-linter:slim-v5`
 
 #### Standard Image
 
-The standard `github/super-linter:v4` comes with all supported linters.
+The standard `github/super-linter:v5` comes with all supported linters.
 Example usage:
 
 ```yml
@@ -229,7 +229,7 @@ Example usage:
 # Run Linter against code base #
 ################################
 - name: Lint Code Base
-  uses: github/super-linter@v4
+  uses: github/super-linter@v5
   env:
     VALIDATE_ALL_CODEBASE: false
     DEFAULT_BRANCH: master
@@ -238,7 +238,7 @@ Example usage:
 
 #### Slim Image
 
-The slim `github/super-linter:slim-v4` comes with all supported linters but removes the following:
+The slim `github/super-linter:slim-v5` comes with all supported linters but removes the following:
 
 - `rust` linters
 - `dotenv` linters
@@ -255,7 +255,7 @@ Example usage:
 # Run Linter against code base #
 ################################
 - name: Lint Code Base
-  uses: github/super-linter/slim@v4
+  uses: github/super-linter/slim@v5
   env:
     VALIDATE_ALL_CODEBASE: false
     DEFAULT_BRANCH: master
@@ -487,7 +487,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: github/super-linter@v5
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
@@ -560,7 +560,7 @@ Once found, it will load the certificate contents to a file, and to the trust st
 
 ```yml
 - name: Lint Code Base
-  uses: github/super-linter@v4
+  uses: github/super-linter@v5
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     SSL_CERT_SECRET: ${{ secrets.ROOT_CA }}

--- a/TEMPLATES/linter.yml
+++ b/TEMPLATES/linter.yml
@@ -57,7 +57,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: github/super-linter@v5
         env:
           VALIDATE_ALL_CODEBASE: false
           # Change to 'master' if your main branch differs

--- a/docs/run-linter-locally.md
+++ b/docs/run-linter-locally.md
@@ -57,7 +57,7 @@ This always runs the local docker based linting.
 docker run --rm \
     -e RUN_LOCAL=true \
     --env-file ".github/super-linter.env" \
-    -v "$PWD":/tmp/lint github/super-linter:v4
+    -v "$PWD":/tmp/lint github/super-linter:v5
 ```
 
 ### scripts/test
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: cat .github/super-linter.env >> "$GITHUB_ENV"
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: github/super-linter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: develop


### PR DESCRIPTION
This pull request updates internal references to the `v4` version of this repository to be `v5` with the release of `v5.0.0`.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->

Related to issues #4082 #4083 and #4096.

<!-- markdownlint-disable -->

Fixes #4082 #4083 and #4096.

<!-- markdownlint-restore -->

I simply went through the repository and manually updated references to `super-linter` `v4` to be `v5`.

## Proposed Changes

1. Update `v4` references to be the latest version of the repository.

## Readiness Checklist

### Author/Contributor
- [X] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
